### PR TITLE
chore: 設置 ESLint 配置檔案

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+build
+dist
+node_modules
+public
+!.eslintrc.cjs

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,65 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    jest: true,
+    node: true,
+    es2020: true,
+  },
+  parser: "@typescript-eslint/parser",
+  extends: [
+    "airbnb",
+    "airbnb/hooks",
+    "plugin:react/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended",
+    "next/core-web-vitals",
+    "next/typescript",
+  ],
+  settings: {
+    "import/resolver": {
+      typescript: {},
+      node: {
+        extensions: [".js", ".jsx", ".ts", ".tsx"],
+      },
+    },
+    react: {
+      version: "detect",
+    },
+  },
+  rules: {
+    "no-restricted-exports": 0,
+    "no-use-before-define": "off",
+    "@typescript-eslint/no-explicit-any": 0,
+    "@typescript-eslint/no-use-before-define": ["error", { variables: false }],
+    "@typescript-eslint/no-var-requires": 0,
+    "@typescript-eslint/ban-ts-comment": 0,
+    "global-require": 0,
+    "import/no-extraneous-dependencies": 0,
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
+        js: "never",
+        jsx: "never",
+        ts: "never",
+        tsx: "never",
+      },
+    ],
+    "import/no-import-module-exports": 0,
+    "import/prefer-default-export": 0,
+    "jsx-a11y/no-static-element-interactions": 0,
+    "jsx-a11y/click-events-have-key-events": 0,
+    "no-console": 0,
+    "react/prop-types": 0,
+    "react/button-has-type": 0,
+    "react/function-component-definition": 0,
+    "react/jsx-filename-extension": [
+      1,
+      { extensions: [".js", ".jsx", ".ts", ".tsx"] },
+    ],
+    "react/jsx-props-no-spreading": 0,
+    "react/react-in-jsx-scope": 0,
+    "react/require-default-props": 0,
+  },
+};


### PR DESCRIPTION
# 更改內容

- **新增 `.eslintignore` 設定檔案**  
  排除 `build`、`dist`、`node_modules` 和 `public` 目錄的 ESLint 檢查

- **新增 `.eslintrc.cjs` 設定檔案**  
  配置了完整的 ESLint 規則

# 目的

本次更改建立了專案的 ESLint 配置，確保程式碼風格一致性和品質。  
採用了 Airbnb 風格指南並整合了 TypeScript、React 和 Next.js 的最佳實踐。

# 主要配置特點

- 整合 Airbnb 編碼規範
- 支援 TypeScript 語法檢查
- 整合 Next.js 核心網頁指標
- 支援 React hooks 規則檢查
- 配置 Prettier 以確保格式一致性

# 測試方法

執行 `npm run lint` 確認 ESLint 配置正常運作
