### PR TITLE
chore: 設置 PostCSS 配置檔整合 Tailwind CSS

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    tailwindcss: {},
+  },
+};
+
+export default config;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import Image from "next/image";
 import { Geist, Geist_Mono } from "next/font/google";
-import styles from "@/styles/Home.module.css";
+import styles from "../styles/Home.module.css";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -22,6 +22,11 @@ export default function Home() {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
+
+      <h1 className="text-3xl font-bold underline">
+      Hello world!
+    </h1>
+
       <div
         className={`${styles.page} ${geistSans.variable} ${geistMono.variable}`}
       >

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,21 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: {
+    data: {
+        active: 'active~="true"',
+    },
+    extend: {
+      colors: {
+        background: "var(--background)",
+        foreground: "var(--foreground)",
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config;


### PR DESCRIPTION
# 更改內容

- **新增 `postcss.config.mjs` 配置檔**  
  設置 PostCSS 與 Tailwind CSS 整合

# 目的

本次更改為專案添加了 PostCSS 配置，確保 Tailwind CSS 能正確地與專案整合。  
這是設置 Tailwind CSS 工作流程的重要一步，使我們能夠在專案中使用 Tailwind 的所有功能。

# 技術細節

- 配置了 PostCSS 插件系統以處理 Tailwind CSS
- 使用 ESM 格式設定檔案，符合現代 JavaScript 標準
- 包含完整 TypeScript 類型定義，提升開發體驗

# 測試方法

- 確認 Tailwind CSS 的類別在專案中能被正確解析和應用
- 確認建置流程能正確處理 Tailwind 的指令式 CSS

# 相關依賴

需確保專案已安裝以下相關套件：
- `tailwindcss`
- `postcss`
