### PR TITLE
feat/ recipe-upload-step2

### DIFF
--- a/src/components/RecipeUploadStep1/index.tsx
+++ b/src/components/RecipeUploadStep1/index.tsx
@@ -1,17 +1,18 @@
-import type React from "react";
+import type React from 'react';
 
-import { useState } from "react";
-import { useForm } from "react-hook-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { z } from "zod";
-import { cn } from "@/lib/utils";
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
 
 // 定義表單驗證 schema
 const recipeFormSchema = z.object({
-  recipeName: z.string().min(2, { message: "食譜名稱至少需要 2 個字元" }),
+  recipeName: z.string().min(2, { message: '食譜名稱至少需要 2 個字元' }),
   coverImage: z.instanceof(File).optional(),
   agreement: z.literal(true, {
-    errorMap: () => ({ message: "請同意條款才能繼續" }),
+    errorMap: () => ({ message: '請同意條款才能繼續' }),
   }),
 });
 
@@ -33,14 +34,14 @@ export default function RecipeUploadForm() {
   } = useForm<RecipeFormValues>({
     resolver: zodResolver(recipeFormSchema),
     defaultValues: {
-      recipeName: "",
+      recipeName: '',
       agreement: undefined,
     },
   });
 
   // 處理表單提交
   const atSubmit = (data: RecipeFormValues) => {
-    console.log("表單資料:", data);
+    console.log('表單資料:', data);
     setCurrentStep(2);
   };
 
@@ -60,13 +61,13 @@ export default function RecipeUploadForm() {
     <div className="max-w-2xl mx-auto px-4 py-8">
       {/* 麵包屑導航 */}
       <nav className="flex items-center gap-2 text-sm mb-8">
-        <a href="/" className="hover:underline">
+        <Link href="/" className="hover:underline">
           首頁
-        </a>
+        </Link>
         <span>&gt;</span>
-        <a href="/recipes" className="hover:underline">
+        <Link href="/recipes" className="hover:underline">
           建立食譜
-        </a>
+        </Link>
         <span>&gt;</span>
         <span className="text-gray-500">上傳食譜名稱</span>
       </nav>
@@ -80,10 +81,10 @@ export default function RecipeUploadForm() {
             <div key={step} className="relative flex flex-col items-center">
               <div
                 className={cn(
-                  "w-8 h-8 rounded-full flex items-center justify-center z-10",
+                  'w-8 h-8 rounded-full flex items-center justify-center z-10',
                   currentStep >= step
-                    ? "bg-gray-700 text-white"
-                    : "bg-gray-200 text-gray-500"
+                    ? 'bg-gray-700 text-white'
+                    : 'bg-gray-200 text-gray-500',
                 )}
               >
                 {step}
@@ -98,7 +99,11 @@ export default function RecipeUploadForm() {
       <form onSubmit={handleSubmit(atSubmit)}>
         {/* 食譜名稱輸入 */}
         <div className="mb-6">
-          <label htmlFor="recipeName" className="block text-lg font-medium mb-2">
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label
+            htmlFor="recipeName"
+            className="block text-lg font-medium mb-2"
+          >
             輸入食譜名稱
           </label>
           <div className="relative">
@@ -107,10 +112,10 @@ export default function RecipeUploadForm() {
               type="text"
               placeholder="在此輸入食譜名稱"
               className={cn(
-                "w-full px-10 py-3 border rounded-md bg-gray-50",
-                errors.recipeName ? "border-red-500" : "border-gray-300"
+                'w-full px-10 py-3 border rounded-md bg-gray-50',
+                errors.recipeName ? 'border-red-500' : 'border-gray-300',
               )}
-              {...register("recipeName")}
+              {...register('recipeName')}
             />
             <div className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
               <svg
@@ -124,25 +129,33 @@ export default function RecipeUploadForm() {
                 strokeLinecap="round"
                 strokeLinejoin="round"
               >
-                <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"></path>
+                <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
               </svg>
             </div>
           </div>
-          {errors.recipeName && <p className="mt-1 text-sm text-red-500">{errors.recipeName.message}</p>}
+          {errors.recipeName && (
+            <p className="mt-1 text-sm text-red-500">
+              {errors.recipeName.message}
+            </p>
+          )}
         </div>
 
         {/* 上傳封面圖片 */}
         <div className="mb-6">
-          <label htmlFor="coverImage" className="block text-lg font-medium mb-2">
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label
+            htmlFor="coverImage"
+            className="block text-lg font-medium mb-2"
+          >
             上傳封面圖片
           </label>
           <div
             className="border border-gray-300 rounded-md bg-gray-50 p-4 h-64 flex items-center justify-center cursor-pointer"
-            onClick={() => document.getElementById("coverImage")?.click()}
+            onClick={() => document.getElementById('coverImage')?.click()}
           >
             {imagePreview ? (
               <img
-                src={imagePreview || "/placeholder.svg"}
+                src={imagePreview || '/placeholder.svg'}
                 alt="預覽圖片"
                 className="max-h-full max-w-full object-contain"
               />
@@ -159,9 +172,9 @@ export default function RecipeUploadForm() {
                   strokeLinecap="round"
                   strokeLinejoin="round"
                 >
-                  <rect width="18" height="18" x="3" y="3" rx="2" ry="2"></rect>
-                  <circle cx="9" cy="9" r="2"></circle>
-                  <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21"></path>
+                  <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+                  <circle cx="9" cy="9" r="2" />
+                  <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
                 </svg>
               </div>
             )}
@@ -170,7 +183,7 @@ export default function RecipeUploadForm() {
               type="file"
               accept="image/*"
               className="hidden"
-              {...register("coverImage", {
+              {...register('coverImage', {
                 onChange: atImageChange,
               })}
             />
@@ -184,12 +197,19 @@ export default function RecipeUploadForm() {
             <input
               id="agreement"
               type="checkbox"
-              className={cn("w-5 h-5 mr-2", errors.agreement ? "border-red-500" : "")}
-              {...register("agreement")}
+              className={cn(
+                'w-5 h-5 mr-2',
+                errors.agreement ? 'border-red-500' : '',
+              )}
+              {...register('agreement')}
             />
             <span className="text-sm">我已同意XX公司隱私及著作權條款</span>
           </label>
-          {errors.agreement && <p className="mt-1 text-sm text-red-500">{errors.agreement.message}</p>}
+          {errors.agreement && (
+            <p className="mt-1 text-sm text-red-500">
+              {errors.agreement.message}
+            </p>
+          )}
         </div>
 
         {/* 下一步按鈕 */}
@@ -203,4 +223,3 @@ export default function RecipeUploadForm() {
     </div>
   );
 }
-

--- a/src/components/RecipeUploadStep2/index.tsx
+++ b/src/components/RecipeUploadStep2/index.tsx
@@ -1,0 +1,446 @@
+import { useState } from 'react';
+import { useForm, useFieldArray } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { cn } from '@/lib/utils';
+import Link from 'next/link';
+
+// 定義表單驗證 schema
+const recipeStep2Schema = z.object({
+  recipeTitle: z.string().min(2, { message: '食譜標題至少需要 2 個字元' }),
+  recipeDescription: z
+    .string()
+    .min(10, { message: '食譜介紹至少需要 10 個字元' }),
+  ingredients: z
+    .array(
+      z.object({
+        name: z.string().min(1, { message: '請輸入食材名稱' }),
+        amount: z.string().min(1, { message: '請輸入數量' }),
+        unit: z.string().optional(),
+      }),
+    )
+    .min(1, { message: '至少需要一項食材' }),
+  seasonings: z.array(
+    z.object({
+      name: z.string().min(1, { message: '請輸入調料名稱' }),
+      amount: z.string().min(1, { message: '請輸入數量' }),
+      unit: z.string().optional(),
+    }),
+  ),
+  tags: z.array(z.string()).optional(),
+  cookingTime: z.string().min(1, { message: '請輸入烹調時間' }),
+  servings: z.string().min(1, { message: '請輸入人份數' }),
+});
+
+// 定義表單資料型別
+type RecipeStep2Values = z.infer<typeof recipeStep2Schema>;
+
+export default function RecipeUploadStep2() {
+  // 設定目前步驟狀態
+  const [currentStep, setCurrentStep] = useState(2);
+
+  // 初始化 react-hook-form
+  const {
+    register,
+    handleSubmit,
+    control,
+    formState: { errors },
+  } = useForm<RecipeStep2Values>({
+    resolver: zodResolver(recipeStep2Schema),
+    defaultValues: {
+      recipeTitle: '馬鈴薯燉肉',
+      recipeDescription:
+        '食譜簡介料理中加入在生薑燒肉，醬汁香濃厚序，這味甜甜醬醬，豬肉的燒烤味入鍋子！食譜簡介料理中加入在生薑燒肉，醬汁香濃厚序，這味甜甜醬醬，豬肉的燒烤味入鍋子！食譜簡介料理中加入在生薑燒肉，醬汁香濃厚序，這味甜甜醬醬，豬肉的燒烤味入鍋子！',
+      ingredients: [{ name: '馬鈴薯', amount: '2', unit: '顆' }],
+      seasonings: [{ name: '初榨醬油', amount: '1', unit: '小匙' }],
+      cookingTime: '120',
+      servings: '4',
+    },
+  });
+
+  // 使用 useFieldArray 管理動態食材列表
+  const {
+    fields: ingredientFields,
+    append: appendIngredient,
+    remove: removeIngredient,
+  } = useFieldArray({
+    control,
+    name: 'ingredients',
+  });
+
+  // 使用 useFieldArray 管理動態調料列表
+  const {
+    fields: seasoningFields,
+    append: appendSeasoning,
+    remove: removeSeasoning,
+  } = useFieldArray({
+    control,
+    name: 'seasonings',
+  });
+
+  // 處理表單提交
+  const atSubmit = (data: RecipeStep2Values) => {
+    console.log('表單資料:', data);
+    setCurrentStep(3);
+  };
+
+  // 添加新食材
+  const atAddIngredient = () => {
+    appendIngredient({ name: '', amount: '', unit: '' });
+  };
+
+  // 添加新調料
+  const atAddSeasoning = () => {
+    appendSeasoning({ name: '', amount: '', unit: '' });
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-8">
+      {/* 麵包屑導航 */}
+      <nav className="flex items-center gap-2 text-sm mb-8">
+        <Link href="/" className="hover:underline">
+          首頁
+        </Link>
+        <span>&gt;</span>
+        <Link href="/recipes" className="hover:underline">
+          建立食譜
+        </Link>
+        <span>&gt;</span>
+        <span className="text-gray-500">上傳食譜資訊</span>
+      </nav>
+
+      {/* 步驟指示器 */}
+      <div className="mb-10">
+        <div className="relative flex items-center justify-between">
+          <div className="absolute left-0 right-0 top-1/2 h-0.5 -translate-y-1/2 bg-gray-200" />
+
+          {[1, 2, 3].map((step) => (
+            <div key={step} className="relative flex flex-col items-center">
+              <div
+                className={cn(
+                  'w-8 h-8 rounded-full flex items-center justify-center z-10',
+                  currentStep >= step
+                    ? 'bg-gray-700 text-white'
+                    : 'bg-gray-200 text-gray-500',
+                )}
+              >
+                {step}
+              </div>
+              <span className="mt-2 text-sm font-medium">Step {step}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* 表單 */}
+      <form onSubmit={handleSubmit(atSubmit)}>
+        {/* 食譜標題 */}
+        <div className="mb-6 border-t border-b border-dashed border-gray-300 py-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-medium">馬鈴薯燉肉</h2>
+            <button
+              type="button"
+              className="text-gray-500"
+              aria-label="編輯食譜標題"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* 食譜介紹 */}
+        <div className="mb-6">
+          {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+          <label
+            htmlFor="recipeDescription"
+            className="block text-lg font-medium mb-2"
+          >
+            輸入食譜介紹
+          </label>
+          <textarea
+            id="recipeDescription"
+            rows={10}
+            className={cn(
+              'w-full p-3 border rounded-md bg-gray-50',
+              errors.recipeDescription ? 'border-red-500' : 'border-gray-300',
+            )}
+            {...register('recipeDescription')}
+          />
+          {errors.recipeDescription && (
+            <p className="mt-1 text-sm text-red-500">
+              {errors.recipeDescription.message}
+            </p>
+          )}
+        </div>
+
+        {/* 所需食材 */}
+        <div className="mb-6">
+          <h2 className="text-lg font-medium mb-2">所需食材</h2>
+
+          {ingredientFields.map((field, index) => (
+            <div key={field.id} className="flex items-center gap-2 mb-2">
+              <div className="flex-1">
+                <input
+                  type="text"
+                  placeholder="食材"
+                  className={cn(
+                    'w-full p-2 border rounded-md',
+                    errors.ingredients?.[index]?.name
+                      ? 'border-red-500'
+                      : 'border-gray-300',
+                  )}
+                  {...register(`ingredients.${index}.name`)}
+                />
+              </div>
+              <div className="w-16">
+                <input
+                  type="text"
+                  placeholder="數量"
+                  className={cn(
+                    'w-full p-2 border rounded-md',
+                    errors.ingredients?.[index]?.amount
+                      ? 'border-red-500'
+                      : 'border-gray-300',
+                  )}
+                  {...register(`ingredients.${index}.amount`)}
+                />
+              </div>
+              <div className="w-16">
+                <input
+                  type="text"
+                  placeholder="單位"
+                  className="w-full p-2 border border-gray-300 rounded-md"
+                  {...register(`ingredients.${index}.unit`)}
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => removeIngredient(index)}
+                className="text-gray-500"
+                aria-label="刪除食材"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M18 6 6 18" />
+                  <path d="m6 6 12 12" />
+                </svg>
+              </button>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            onClick={atAddIngredient}
+            className="flex items-center text-gray-500 mt-2"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <path d="M12 8v8" />
+              <path d="M8 12h8" />
+            </svg>
+            <span className="ml-1">食材</span>
+          </button>
+        </div>
+
+        {/* 所需調料 */}
+        <div className="mb-6">
+          <h2 className="text-lg font-medium mb-2">所需調料</h2>
+
+          {seasoningFields.map((field, index) => (
+            <div key={field.id} className="flex items-center gap-2 mb-2">
+              <div className="flex-1">
+                <input
+                  type="text"
+                  placeholder="調料"
+                  className={cn(
+                    'w-full p-2 border rounded-md',
+                    errors.seasonings?.[index]?.name
+                      ? 'border-red-500'
+                      : 'border-gray-300',
+                  )}
+                  {...register(`seasonings.${index}.name`)}
+                />
+              </div>
+              <div className="w-16">
+                <input
+                  type="text"
+                  placeholder="數量"
+                  className={cn(
+                    'w-full p-2 border rounded-md',
+                    errors.seasonings?.[index]?.amount
+                      ? 'border-red-500'
+                      : 'border-gray-300',
+                  )}
+                  {...register(`seasonings.${index}.amount`)}
+                />
+              </div>
+              <div className="w-16">
+                <input
+                  type="text"
+                  placeholder="單位"
+                  className="w-full p-2 border border-gray-300 rounded-md"
+                  {...register(`seasonings.${index}.unit`)}
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => removeSeasoning(index)}
+                className="text-gray-500"
+                aria-label="刪除調料"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M18 6 6 18" />
+                  <path d="m6 6 12 12" />
+                </svg>
+              </button>
+            </div>
+          ))}
+
+          <button
+            type="button"
+            onClick={atAddSeasoning}
+            className="flex items-center text-gray-500 mt-2"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <path d="M12 8v8" />
+              <path d="M8 12h8" />
+            </svg>
+            <span className="ml-1">調料</span>
+          </button>
+        </div>
+
+        {/* 食譜標籤 */}
+        <div className="mb-6">
+          <h2 className="text-lg font-medium mb-2">食譜標籤</h2>
+          <div className="bg-gray-200 p-3 rounded-md">
+            <div className="flex justify-between items-center mb-2">
+              <span>增加新標籤 (0/5)</span>
+            </div>
+            <input
+              type="text"
+              placeholder="輸入自訂標籤"
+              className="w-full p-2 border border-gray-300 rounded-md bg-white"
+            />
+          </div>
+        </div>
+
+        {/* 烹調時間和人份 */}
+        <div className="mb-6 flex gap-4">
+          <div className="flex-1">
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <label
+              htmlFor="cookingTime"
+              className="block text-lg font-medium mb-2"
+            >
+              烹調時間
+            </label>
+            <div className="flex items-center">
+              <input
+                id="cookingTime"
+                type="number"
+                className={cn(
+                  'w-full p-2 border rounded-md',
+                  errors.cookingTime ? 'border-red-500' : 'border-gray-300',
+                )}
+                {...register('cookingTime')}
+              />
+              <span className="ml-2">分鐘</span>
+            </div>
+            {errors.cookingTime && (
+              <p className="mt-1 text-sm text-red-500">
+                {errors.cookingTime.message}
+              </p>
+            )}
+          </div>
+
+          <div className="flex-1">
+            {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+            <label
+              htmlFor="servings"
+              className="block text-lg font-medium mb-2"
+            >
+              幾人份
+            </label>
+            <div className="flex items-center">
+              <input
+                id="servings"
+                type="number"
+                className={cn(
+                  'w-full p-2 border rounded-md',
+                  errors.servings ? 'border-red-500' : 'border-gray-300',
+                )}
+                {...register('servings')}
+              />
+              <span className="ml-2">人份</span>
+            </div>
+            {errors.servings && (
+              <p className="mt-1 text-sm text-red-500">
+                {errors.servings.message}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* 下一步按鈕 */}
+        <button
+          type="submit"
+          className="w-full py-3 bg-gray-400 text-white rounded-md hover:bg-gray-500 transition-colors"
+        >
+          下一步
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/upload-recipe-step1/index.tsx
+++ b/src/pages/upload-recipe-step1/index.tsx
@@ -1,5 +1,5 @@
 import { NextPage } from 'next';
-import RecipeUploadForm from '@/components/RecipeUploadLayout';
+import RecipeUploadForm from '@/components/RecipeUploadStep1';
 
 // 建立食譜頁面
 const CreateRecipePage: NextPage = () => {

--- a/src/pages/upload-recipe-step2/index.tsx
+++ b/src/pages/upload-recipe-step2/index.tsx
@@ -1,0 +1,10 @@
+import RecipeUploadStep2 from '@/components/RecipeUploadStep2';
+
+// 建立食譜第二步頁面
+export default function CreateRecipeStep2Page() {
+  return (
+    <div className="min-h-screen bg-white">
+      <RecipeUploadStep2 />
+    </div>
+  );
+}


### PR DESCRIPTION
# 新增食譜上傳多步驟表單功能

## 描述

此 PR 實現了食譜上傳功能的多步驟表單系統，使用者可以分階段完成食譜的建立：

1. **分步驟表單架構**：
   - 導入 `RecipeUploadStep1` 元件：用於食譜基本資訊（名稱、封面圖片）的輸入與驗證
   - 導入 `RecipeUploadStep2` 元件：支援食譜詳細資訊（介紹、食材、調料）的管理

2. **食材和調料管理**：
   - 使用 `useFieldArray` 實現動態食材和調料列表管理
   - 可自由新增、刪除食材和調料項目
   - 支援數量和單位的設定

3. **表單驗證增強**：
   - 全面的 zod schema 驗證規則，確保所有必填資訊完整
   - 詳細的錯誤提示，提升使用者體驗

4. **UI優化**：
   - 整合 Next.js Link 元件改善導航體驗
   - 使用 ESLint 相關註解處理無障礙性問題
   - 優化條件渲染的格式，提高程式碼可讀性

5. **跨頁面導航**：
   - 分步驟表單使用獨立路由，支援直接訪問特定步驟
   - 保留步驟指示器，清晰展示用戶在多步驟流程中的進度

此功能擴展了現有的食譜上傳功能，讓用戶能夠更加結構化地管理食譜信息，特別是複雜的食材和調料列表，大幅提升整體使用體驗。
