### PR TITLE
fix/ recipe-video-api-fetch

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -13,6 +13,7 @@ export default function App({ Component, pageProps }: AppProps) {
     '/login-email',
     '/login-verify',
     '/signin-email',
+    '/recipe-video',
   ];
   const shouldUseLayout = !noLayoutPages.includes(router.pathname);
 

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1366,19 +1366,30 @@ export const fetchRecipeTeaching = async (
   recipeId: number,
 ): Promise<RecipeTeachingResponse> => {
   try {
-    console.log(`發送請求: GET /api/recipes/${recipeId}/teaching`);
+    console.log(
+      `發送請求: GET ${apiConfig.baseUrl}/recipes/${recipeId}/teaching`,
+    );
 
-    // 發送請求到 Next.js API 路由
-    const response = await fetch(`/api/recipes/${recipeId}/teaching`, {
-      method: 'GET',
-      credentials: 'include', // 包含 Cookie
-    });
+    // 直接使用 apiConfig.baseUrl 發起請求，而不是經過 Next.js API 路由
+    // 因為根據 API 文檔，公開食譜不需要授權，所以不要直接添加 credentials
+    const response = await fetch(
+      `${apiConfig.baseUrl}/recipes/${recipeId}/teaching`,
+      {
+        method: 'GET',
+      },
+    );
 
     if (!response.ok) {
       if (response.status === 404) {
         return {
           StatusCode: 404,
           msg: '找不到該食譜的教學資訊',
+        };
+      }
+      if (response.status === 401) {
+        return {
+          StatusCode: 401,
+          msg: '尚未公開的食譜無法觀看教學',
         };
       }
 


### PR DESCRIPTION
# 優化食譜教學 API 請求邏輯

## 變更說明
改進 `fetchRecipeTeaching` 函式的實作，直接使用 `apiConfig.baseUrl` 發送請求到後端 API，並強化錯誤處理機制，特別是針對未公開食譜的情況。這次更新提升了 API 請求的效率和錯誤處理的完整性。

### 主要更新
1. API 請求路徑優化
   - 改用 `apiConfig.baseUrl` 直接發送請求
   - 移除透過 Next.js API 路由的間接請求
   - 優化請求設定

2. 錯誤處理強化
   - 新增 401 狀態碼處理
   - 改善錯誤訊息內容
   - 優化錯誤回應結構

### 技術實作細節
#### API 請求路徑更新
```diff
- const response = await fetch(`/api/recipes/${recipeId}/teaching`, {
-   method: 'GET',
-   credentials: 'include', // 包含 Cookie
- });

+ const response = await fetch(
+   `${apiConfig.baseUrl}/recipes/${recipeId}/teaching`,
+   {
+     method: 'GET',
+   },
+ );
```

#### 錯誤處理改進
```typescript
if (response.status === 401) {
  return {
    StatusCode: 401,
    msg: '尚未公開的食譜無法觀看教學',
  };
}
```

### 功能改進
1. 請求效率
   - 移除多餘的請求轉發
   - 減少請求延遲
   - 優化資源使用

2. 錯誤處理
   - 完整的狀態碼處理
   - 明確的錯誤訊息
   - 結構化的錯誤回應

3. 程式碼品質
   - 改善程式碼可讀性
   - 優化註解說明
   - 統一錯誤處理模式

### 測試項目
- [x] 公開食譜請求
- [x] 未公開食譜請求
- [x] 404 錯誤處理
- [x] 401 錯誤處理
- [x] 一般錯誤處理
- [x] 請求路徑正確性
- [x] 回應格式一致性

### 相關影響
- 提升 API 請求效率
- 改善錯誤處理體驗
- 優化程式碼結構
- 增強系統穩定性

### 注意事項
- 移除了 credentials 設定
- 確保 apiConfig.baseUrl 設定正確
- 監控錯誤回應的準確性
- 注意未公開食譜的存取控制