### PR TITLE
fix: remove stale test trigger branch and tighten OIDC trust scope

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to AWS
 on:
   workflow_dispatch:
   push:
-    branches: [main, feat/ci-cd-deploy] # TODO: 驗證通過後移除 feat/ci-cd-deploy
+    branches: [main]
 
 # id-token: write 是 OIDC 換取短期 AWS 憑證的必要權限
 permissions:


### PR DESCRIPTION
## 背景

PR #158 merge 後複查發現：驗證用的暫時清理 commit 因為時間差沒趕上 merge，導致 `dev` 上殘留 `branches: [main, feat/ci-cd-deploy]`。順便做一次完整資安複查。

## 變更內容

- `deploy.yml`：push 觸發條件收回只剩 `main`
- （AWS 端，不在此 PR）IAM Role `gha-anna-cook-deploy` 信任條件由萬用字元 `repo:heyi5478/anna-cook:*` 收緊為 `repo:heyi5478/anna-cook:ref:refs/heads/main`——現有觸發條件下本來就不可被利用，此為 defense-in-depth，避免未來加其他 workflow/trigger 時不小心擴大範圍

## 複查結論（無密鑰外洩、無 injection 風險）

- 無任何 access key／密碼寫死在檔案內，全程 OIDC 換短期憑證
- `AWS_ROLE_ARN` 用 GitHub `vars`（非 secrets）合理——ARN 本身非機密，需通過 OIDC trust 驗證才可用
- `run:` 區塊僅引用 `github.sha`（格式固定）與自訂 env，未引用任何外部可控字串，無 shell injection 風險
- 未監聽 `pull_request`/`pull_request_target`，外部 fork PR 無法觸發此 workflow

## 驗證

- ⏳ merge 後確認 dev 上 deploy.yml 內容正確（僅 `branches: [main]`）