### PR TITLE
docs: add OpenSpec proposal for security hardening (Tier A)

### DIFF
--- a/openspec/changes/security-hardening-tier-a/.openspec.yaml
+++ b/openspec/changes/security-hardening-tier-a/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/security-hardening-tier-a/design.md
+++ b/openspec/changes/security-hardening-tier-a/design.md
@@ -1,0 +1,51 @@
+## Context
+
+Tier A 來自先前的前端資安檢查，定義為「可在不影響現有功能下立即處理」的加固類項目。相關背景：
+
+- 前端 Next.js（Pages Router）主要作為代理層，實際認證由後端負責。
+- 真正的 session 已使用 **HttpOnly cookie**（伺服器端登入路由設定），但另有**死碼**會把 JWT 複製到 `localStorage` 與非 HttpOnly cookie（`getAuthToken()` 無任何呼叫端、客戶端無 `Authorization` 直傳，已於檢查中確認）。
+- JSON-LD 透過 `dangerouslySetInnerHTML` 輸出；食譜名稱/描述（使用者生成內容）會流入，形成可達的儲存型 XSS。
+- 專案嵌入 Vimeo 播放器，並在 `_document.tsx` 載入 GTM（含 inline script）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 消除食譜詳細頁可達的**儲存型 XSS**（JSON-LD 未跳脫）。
+- 加上基礎安全性 HTTP 標頭（不含 CSP）。
+- 停止把 token 寫入日誌。
+- 讓 HttpOnly cookie 成為**唯一**的 token 存放處，移除 JS 可讀的複本。
+- 停止向客戶端洩漏內部例外訊息。
+- 全程對合法使用者**零功能影響**。
+
+**Non-Goals:**
+- **CSP**：會擋到 Vimeo/GTM，需以 report-only 逐步導入 → 留待後續 Tier。
+- **JWT 驗簽 / `check-current-user`**：前端無簽章密鑰，屬後端責任 → Tier C。
+- 上傳大小/型別限制（Tier B）、OAuth `state`、路徑參數驗證、Next.js 升級。
+
+## Decisions
+
+1. **JSON-LD 跳脫**：在 `StructuredData.tsx` 的 `generateJsonLd` 對 `JSON.stringify` 結果跳脫 `<`→`<`、`>`→`>`、`&`→`&`、` `、` `。
+   - 為何：Next.js 官方建議做法，輸出仍是**合法 JSON-LD**（解析器會還原跳脫），零新相依、零語意變化。
+   - 替代方案：改用 sanitizer 套件或 `next/script` → 否決（過度、增加相依）。
+2. **安全標頭**：以 `next.config.ts` 的 `headers()` 全站套用，而非 per-route 或 middleware。
+   - 為何：單一來源、Pages Router 原生支援、無執行期成本。
+   - 值：`X-Content-Type-Options: nosniff`、`X-Frame-Options: SAMEORIGIN`、`Referrer-Policy: strict-origin-when-cross-origin`、`Strict-Transport-Security`（中等 max-age、暫不 preload）、`Permissions-Policy`（未使用的功能一律 deny）、`poweredByHeader: false`。**刻意不含 CSP。**
+3. **Token 單一存放**：移除 `setClientCookie(httpOnly:false)`、`updateAuthToken` 的 `localStorage('authToken')`、`getAuthToken()`；保留與 token 無關的 `userData` localStorage（UI 狀態）。移除各處把含 token 的 cookie 字串寫入 log 的呼叫。
+   - 為何：HttpOnly cookie 已是實際 session 來源；死碼移除可縮小 XSS 影響面。
+4. **錯誤回應一般化**：API route 回傳穩定的一般化訊息，內部細節改用 `console.error` 留在伺服器端。
+
+## Risks / Trade-offs
+
+- [JSON-LD 跳脫破壞結構化資料] → 這些是標準 JSON 字串跳脫，解析器會還原，語意不變；以 Google Rich Results 測試驗證。
+- [`X-Frame-Options` 擋掉合法嵌入] → 食譜站不被他站 iframe；選 `SAMEORIGIN` 而非 `DENY` 保留同源。
+- [HSTS 鎖死 HTTPS] → 生產環境已強制 HTTPS；用中等 max-age、初期不加 preload。
+- [移除 token 死碼其實有隱藏使用者] → 已 grep 確認無呼叫端；以 `npm run build` + 既有測試把關。
+
+## Migration Plan
+
+純新增設定與死碼移除，**無資料遷移**。走既有部署流程；回滾＝revert 該 commit；無環境變數變更。
+
+## Open Questions
+
+- HSTS 的 `max-age` 最終值、是否日後加入 `preload`。
+- `Permissions-Policy` 要 deny 的功能清單（提案：camera/microphone/geolocation 等未使用者全 deny）。

--- a/openspec/changes/security-hardening-tier-a/proposal.md
+++ b/openspec/changes/security-hardening-tier-a/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+先前對 anna-cook 前端的資安檢查發現多項問題。本提案只納入 **Tier A** —— 可在**不影響現有功能**的前提下立即處理的加固／死碼清除／設定類項目，先解決「風險最高、改動最小」的部分。其中最嚴重的是食譜詳細頁的**儲存型 XSS**（JSON-LD 未跳脫）：任何註冊使用者只要把食譜命名為含 `</script>` 的字串，即可對全站訪客執行任意 JavaScript。
+
+## What Changes
+
+- **JSON-LD 輸出跳脫**：`StructuredData.tsx` 用 `JSON.stringify` 產生的內容經 `dangerouslySetInnerHTML` 注入 `<script type="application/ld+json">`，未跳脫 `<`/`>`/`&`，使食譜名稱/描述可突破 `<script>` 注入腳本。改為跳脫這些字元，消除儲存型 XSS。
+- **HTTP 安全標頭**：`next.config.ts` 新增 `X-Content-Type-Options`、`X-Frame-Options`、`Referrer-Policy`、`Strict-Transport-Security`、`Permissions-Policy`，並關閉 `poweredByHeader`。（**不含 CSP** —— CSP 會影響 Vimeo 播放器與 GTM，屬後續 Tier。）
+- **移除日誌中的 token**：`setServerCookie` 等處會把含 JWT 的完整 cookie 字串寫進伺服器日誌，予以移除；並修正 `setServerCookie` 中與實際行為矛盾的 log 文字。
+- **統一 token 存放為 HttpOnly**：移除已成死碼的 localStorage token 與非 HttpOnly cookie 寫入路徑（`setClientCookie` 的 `httpOnly:false`、`updateAuthToken` 寫 `localStorage('authToken')`、`getAuthToken`），保留與 token 無關的 `userData` localStorage。
+- **API 錯誤訊息一般化**：多個 API route 目前把內部 `error.message` 回傳給客戶端，改為回傳一般化訊息，詳細只記在伺服器端。
+
+以上皆為**非破壞性**變更，對合法使用者無任何可見的功能差異。
+
+## Capabilities
+
+### New Capabilities
+- `structured-data-rendering`: 結構化資料（JSON-LD）輸出到 HTML 時，對 HTML 敏感字元的安全跳脫要求
+- `http-security-headers`: 前端回應必須帶上的安全性 HTTP 標頭（本階段不含 CSP）
+- `auth-token-security`: JWT token 的存放與日誌處理 —— 僅存於 HttpOnly cookie、且不得寫入任何日誌
+- `api-error-handling`: API 錯誤回應不得向客戶端洩漏內部例外細節
+
+### Modified Capabilities
+_(無 —— `openspec/specs/` 目前為空，無既有 capability 的需求被更動)_
+
+## Impact
+
+- **程式碼**：`src/components/seo/StructuredData.tsx`、`next.config.ts`、`src/lib/utils/auth.ts`、`src/services/utils/http.ts`、`src/services/server-api.ts`、`src/pages/api/**`（多個 route 的錯誤回應）
+- **相依套件**：無變更
+- **行為相容性**：對一般使用者**零功能影響**（Tier A 定義）；`getAuthToken()`、`setClientCookie()` 等為死碼移除，已於資安檢查中確認無呼叫端
+- **不在本次範圍（留待後續 Tier）**：CSP（Tier C）、JWT 驗簽 / `check-current-user`（Tier C）、上傳大小與型別限制（Tier B）、OAuth `state`、路徑參數驗證、Next.js 版本升級

--- a/openspec/changes/security-hardening-tier-a/specs/api-error-handling/spec.md
+++ b/openspec/changes/security-hardening-tier-a/specs/api-error-handling/spec.md
@@ -1,0 +1,8 @@
+## ADDED Requirements
+
+### Requirement: API 錯誤回應不得洩漏內部細節
+API route 發生例外時 SHALL 回傳一般化的錯誤訊息，且 MUST NOT 在回應中包含內部例外訊息（如 `error.message`）、堆疊追蹤或後端原始回應內容。內部細節 SHALL 改記錄於伺服器端日誌。
+
+#### Scenario: 處理請求時擲出例外
+- **WHEN** 某 API route 在處理或代理請求時擲出例外
+- **THEN** 客戶端收到不含內部例外字串的一般化錯誤訊息，且詳細內容記錄於伺服器端 `console.error`

--- a/openspec/changes/security-hardening-tier-a/specs/auth-token-security/spec.md
+++ b/openspec/changes/security-hardening-tier-a/specs/auth-token-security/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: JWT token 僅存於 HttpOnly cookie
+系統 SHALL 只把認證 token 存放於 HttpOnly cookie；MUST NOT 將 token 寫入 `localStorage` 或任何 JavaScript 可讀的 cookie。與 token 無關的非敏感 UI 狀態（如 `userData`）不受此限。
+
+#### Scenario: 登入後檢視客戶端儲存
+- **WHEN** 使用者成功登入
+- **THEN** token 只存在於 HttpOnly cookie，`localStorage` 與 `document.cookie` 皆不含 token
+
+### Requirement: 不得將 token 寫入日誌
+系統 MUST NOT 把認證 token（或含 token 的完整 cookie 字串）寫入伺服器端或客戶端日誌。
+
+#### Scenario: 設定或換發 token cookie
+- **WHEN** 伺服器端設定或換發 token cookie
+- **THEN** 日誌中不出現 token 值或含 token 的完整 cookie 字串

--- a/openspec/changes/security-hardening-tier-a/specs/http-security-headers/spec.md
+++ b/openspec/changes/security-hardening-tier-a/specs/http-security-headers/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: 全站回應必須帶基礎安全性標頭
+應用程式 SHALL 對所有頁面與 API 回應附上下列標頭：`X-Content-Type-Options: nosniff`、`X-Frame-Options: SAMEORIGIN`、`Referrer-Policy: strict-origin-when-cross-origin`、`Strict-Transport-Security`（含 max-age）、以及 `Permissions-Policy`（未使用之瀏覽器功能一律停用）。
+
+#### Scenario: 一般頁面回應
+- **WHEN** 客戶端請求任一頁面或 API
+- **THEN** 回應包含上述所有安全性標頭
+
+### Requirement: 不得洩漏框架指紋
+應用程式 MUST NOT 回傳 `X-Powered-By` 標頭。
+
+#### Scenario: 檢視回應標頭
+- **WHEN** 檢視任一回應的標頭
+- **THEN** 回應中不存在 `X-Powered-By` 標頭

--- a/openspec/changes/security-hardening-tier-a/specs/structured-data-rendering/spec.md
+++ b/openspec/changes/security-hardening-tier-a/specs/structured-data-rendering/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: JSON-LD 輸出必須跳脫 HTML 敏感字元
+系統 SHALL 在把結構化資料（JSON-LD）以 `dangerouslySetInnerHTML` 寫入 `<script type="application/ld+json">` 之前，跳脫 `<`、`>`、`&` 以及 U+2028／U+2029，使任何欄位值都無法突破 `<script>` 標籤。
+
+#### Scenario: 食譜名稱含 script 關閉標籤
+- **WHEN** 某食譜名稱為 `蛋炒飯</script><script>alert(1)</script>` 且被渲染到食譜詳細頁
+- **THEN** 輸出的 JSON-LD 中 `<` 以 `<` 表示，瀏覽器不會執行任何被注入的腳本
+
+#### Scenario: 一般內容語意不變
+- **WHEN** 結構化資料只含一般文字（無 HTML 敏感字元）
+- **THEN** 輸出仍為合法且語意相同的 JSON-LD，結構化資料的解析結果不變

--- a/openspec/changes/security-hardening-tier-a/tasks.md
+++ b/openspec/changes/security-hardening-tier-a/tasks.md
@@ -1,0 +1,28 @@
+## 1. JSON-LD XSS 跳脫（structured-data-rendering）
+
+- [ ] 1.1 在 `src/components/seo/StructuredData.tsx` 的 `generateJsonLd` 對 `JSON.stringify` 結果跳脫 `<`→`<`、`>`→`>`、`&`→`&`、` `、` `
+- [ ] 1.2 手動驗證：以含 `</script>` 的食譜名稱渲染食譜詳細頁，確認腳本不執行且結構化資料仍為合法 JSON-LD
+
+## 2. HTTP 安全標頭（http-security-headers）
+
+- [ ] 2.1 在 `next.config.ts` 新增 `async headers()`，套用 `X-Content-Type-Options: nosniff`、`X-Frame-Options: SAMEORIGIN`、`Referrer-Policy: strict-origin-when-cross-origin`、`Strict-Transport-Security`（中等 max-age、不 preload）、`Permissions-Policy`（未使用功能 deny）
+- [ ] 2.2 設定 `poweredByHeader: false`
+- [ ] 2.3 驗證：`curl -I` 確認上述標頭存在且無 `X-Powered-By`（**不加 CSP**）
+
+## 3. Token 安全（auth-token-security）
+
+- [ ] 3.1 移除 `src/services/utils/http.ts` 中 `updateAuthToken` 寫入 `localStorage('authToken')` 與 `getAuthToken()`（保留與 token 無關的 `userData` localStorage）
+- [ ] 3.2 移除／停用 `src/lib/utils/auth.ts` 的 `setClientCookie`（`httpOnly:false`）死碼路徑
+- [ ] 3.3 移除把含 token 的完整 cookie 字串寫入日誌的 `console.log`（`setServerCookie` 等），並修正其中與實際行為矛盾的 log 文字
+- [ ] 3.4 `grep` 確認無殘留呼叫端後 `npm run build` 通過
+
+## 4. API 錯誤訊息一般化（api-error-handling）
+
+- [ ] 4.1 盤點所有回傳 `error: error.message` / 內部細節的 API route（含 `src/lib/auth-middleware.ts` 的 `proxyAuthRequest`）
+- [ ] 4.2 改為回傳一般化錯誤訊息，內部細節改以 `console.error` 記在伺服器端
+
+## 5. 驗收
+
+- [ ] 5.1 `npm run build` 與既有 Jest 測試全數通過
+- [ ] 5.2 `npx openspec validate security-hardening-tier-a --strict` 通過
+- [ ] 5.3 逐頁走查（首頁／食譜詳細／登入）確認無功能回歸


### PR DESCRIPTION
## 摘要

以 OpenSpec 建立**前端資安加固 Tier A** 的變更提案（**僅規格文件，不含程式碼改動**）。實作將於後續獨立 PR 進行，讓「規格」與「實作」分開審閱。

Tier A = 可在**不影響現有功能**下立即處理的加固／死碼清除／設定類項目。

## 內容：`openspec/changes/security-hardening-tier-a/`

- **`proposal.md`** — Why / What Changes / Capabilities / Impact
- **`design.md`** — 關鍵技術決策、風險與緩解、回滾計畫
- **`specs/`**（4 個 capability）
  - `structured-data-rendering` — JSON-LD 輸出跳脫（消除食譜頁儲存型 XSS）
  - `http-security-headers` — 基礎安全標頭（**不含 CSP**）
  - `auth-token-security` — token 僅存 HttpOnly、不寫入日誌
  - `api-error-handling` — 錯誤回應不洩漏內部細節
- **`tasks.md`** — 14 個實作／驗收任務

## 明確不在範圍（留待後續 Tier）

CSP、JWT 驗簽 / `check-current-user`（Tier C）、上傳大小與型別限制（Tier B）、OAuth `state`、路徑參數驗證、Next.js 升級。

## 驗證

`openspec validate security-hardening-tier-a --strict` ✅ 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
