### PR TITLE
docs: add OpenSpec proposals for security Tier B & C

### DIFF
--- a/openspec/changes/security-hardening-tier-b/.openspec.yaml
+++ b/openspec/changes/security-hardening-tier-b/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/security-hardening-tier-b/design.md
+++ b/openspec/changes/security-hardening-tier-b/design.md
@@ -1,0 +1,35 @@
+## Context
+
+Tier B 來自資安檢查，特性是「非破壞性但需選對參數/測試」。上傳端點以 `formidable` 解析並用 `fs.readFileSync` 整檔進記憶體轉發；`proxyAuthRequest` 以字串串接路徑參數組成後端 URL。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 檔案上傳有大小/型別界限且以串流處理。
+- 無已知 high/critical 相依漏洞、框架保持受支援版本。
+- 路徑參數安全地組成後端 URL。
+
+**Non-Goals:**
+- CSP、JWT 驗簽、OAuth state（皆屬 Tier C）。
+- 改變合法使用者可見的功能行為。
+
+## Decisions
+
+1. **上傳限制**：以 `formidable({ maxFileSize, filter })` 實作——`maxFileSize` 設 ≥ 合法上限並對齊後端；`filter` 用 mimetype 白名單（影片端點放影片、頭像放圖片）。`readFileSync` → 以 stream/pipe 轉發，避免整檔進記憶體。
+2. **相依**：先連網 `npm audit` 取得 high/critical 清單，升級到最新 15.x（patch/minor），跑 `npm run build` + jest 驗證；必要時逐一評估 breaking。
+3. **路徑參數**：以 `encodeURIComponent` 包裹（對數字/英數 ID 透明）；明確為數字的 ID（如 recipeId）可加格式驗證。
+
+## Risks / Trade-offs
+
+- [maxFileSize 設太低擋掉合法上傳] → 設 ≥ 實際上限並對齊後端，以實測驗證。
+- [Next 升級引入行為變更] → 只在 15.x 內升，跑 build + 測試把關。
+- [路徑參數嚴格驗證擋掉合法值] → 以 `encodeURIComponent` 為主（透明），格式驗證僅用於明確數字型 ID。
+
+## Migration Plan
+
+無資料遷移；升級 + 設定調整；回滾＝revert 對應 commit。
+
+## Open Questions
+
+- 各端點的 `maxFileSize` 上限值（需對齊後端與實際需求）。
+- Next.js 目標版本（依 `npm audit` 結果決定）。

--- a/openspec/changes/security-hardening-tier-b/proposal.md
+++ b/openspec/changes/security-hardening-tier-b/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+延續前端資安檢查（Tier A 已完成並歸檔）。本提案納入 **Tier B** —— 幾乎不影響正常使用、但需要選對參數並實測的加固項目：檔案上傳的資源界限、相依套件的已知漏洞、路徑參數的縱深防禦。對應 issue #164。
+
+## What Changes
+
+- **檔案上傳大小/型別限制 + 串流**：`video.ts`、`user/profile.ts`、`create.ts`、`submit-draft.ts` 目前用 `formidable({})`，無 `maxFileSize` 與型別白名單，且 `fs.readFileSync` 把整檔讀進記憶體 → 大檔（尤其影片）可 OOM。加入大小上限（≥ 合法上限、對齊後端）、mimetype 白名單，並改串流轉發。
+- **相依套件漏洞**：`next@15.2.3` 落後多個安全修補版；連網跑 `npm audit`、升級到最新 15.x。
+- **路徑參數驗證/編碼**：`proxyAuthRequest` 的 `url` 由 caller 用路徑參數串接，僅檢查存在/陣列。加入 `encodeURIComponent` 或格式驗證。
+
+## Capabilities
+
+### New Capabilities
+- `file-upload-limits`: 檔案上傳的大小上限、型別白名單與串流處理
+- `dependency-security`: 相依套件不得含已知高風險漏洞、框架保持在受支援版本
+- `api-path-parameter-safety`: 路徑參數在組成後端 URL 前需驗證/編碼
+
+### Modified Capabilities
+_(無)_
+
+## Impact
+
+- **程式碼**：`src/pages/api/recipes/[recipeId]/video.ts`、`src/pages/api/user/profile.ts`、`src/pages/api/recipes/create.ts`、`src/pages/api/recipes/[recipeId]/submit-draft.ts`、`src/lib/auth-middleware.ts`、`package.json`
+- **相依套件**：Next.js 升級
+- **行為相容性**：對合法使用者無感；新增「拒絕過大/錯型別檔案」「拒絕異常路徑參數」的行為，需選對參數並實測

--- a/openspec/changes/security-hardening-tier-b/specs/api-path-parameter-safety/spec.md
+++ b/openspec/changes/security-hardening-tier-b/specs/api-path-parameter-safety/spec.md
@@ -1,0 +1,8 @@
+## ADDED Requirements
+
+### Requirement: 路徑參數組成後端 URL 前必須安全處理
+API 代理 SHALL 在把路徑參數（如 `recipeId` / `userId` / `displayId`）併入後端 URL 前進行編碼或格式驗證，避免注入或非預期路徑。
+
+#### Scenario: 路徑參數含特殊字元
+- **WHEN** 路徑參數包含 `/`、`..` 或其他特殊字元
+- **THEN** 該參數被編碼或被拒絕，後端 URL 不會被竄改

--- a/openspec/changes/security-hardening-tier-b/specs/dependency-security/spec.md
+++ b/openspec/changes/security-hardening-tier-b/specs/dependency-security/spec.md
@@ -1,0 +1,8 @@
+## ADDED Requirements
+
+### Requirement: 不得含已知高風險相依漏洞
+專案 SHALL 保持相依套件無已知的 high/critical 等級安全漏洞，框架維持在受支援版本。
+
+#### Scenario: 執行相依稽核
+- **WHEN** 在有網路的環境執行 `npm audit`
+- **THEN** 無 high 或 critical 等級的未處理漏洞

--- a/openspec/changes/security-hardening-tier-b/specs/file-upload-limits/spec.md
+++ b/openspec/changes/security-hardening-tier-b/specs/file-upload-limits/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: 檔案上傳必須有大小與型別界限
+上傳端點 SHALL 設定 `maxFileSize` 上限並限制允許的 MIME 型別；超過大小或非允許型別的上傳 MUST 被拒絕。
+
+#### Scenario: 上傳超過大小上限的檔案
+- **WHEN** 使用者上傳超過設定 `maxFileSize` 的檔案
+- **THEN** 伺服器拒絕該請求並回傳錯誤，且不會把整檔載入記憶體
+
+#### Scenario: 上傳非允許型別
+- **WHEN** 使用者上傳不在白名單內的 MIME 型別
+- **THEN** 伺服器拒絕該請求
+
+### Requirement: 上傳內容不得整檔載入記憶體
+上傳處理 SHALL 以串流方式轉發到後端，MUST NOT 使用 `fs.readFileSync` 一次性讀入整個檔案。
+
+#### Scenario: 上傳大型影片
+- **WHEN** 使用者上傳大型影片檔
+- **THEN** 內容以串流轉發，記憶體用量不隨檔案大小線性成長

--- a/openspec/changes/security-hardening-tier-b/tasks.md
+++ b/openspec/changes/security-hardening-tier-b/tasks.md
@@ -1,0 +1,21 @@
+## 1. 檔案上傳界限（file-upload-limits）
+
+- [ ] 1.1 `video.ts` / `user/profile.ts` / `create.ts` / `submit-draft.ts` 的 `formidable` 設定 `maxFileSize`（對齊後端）與 mimetype 白名單
+- [ ] 1.2 上傳改以串流轉發，移除 `fs.readFileSync` 整檔讀取
+- [ ] 1.3 實測各端點正常上傳不受影響、過大/錯型別被拒
+
+## 2. 相依套件漏洞（dependency-security）
+
+- [ ] 2.1 連網執行 `npm audit`，記錄 high/critical 清單
+- [ ] 2.2 升級 Next.js 到最新 15.x，跑 `npm run build` + jest
+- [ ] 2.3 處理其餘 high/critical 漏洞
+
+## 3. 路徑參數安全（api-path-parameter-safety）
+
+- [ ] 3.1 `proxyAuthRequest` 與各路由對路徑參數 `encodeURIComponent` / 格式驗證
+- [ ] 3.2 驗證正常 ID 不受影響
+
+## 4. 驗收
+
+- [ ] 4.1 `npm run build` + jest 通過
+- [ ] 4.2 `openspec validate security-hardening-tier-b --strict` 通過

--- a/openspec/changes/security-hardening-tier-c/.openspec.yaml
+++ b/openspec/changes/security-hardening-tier-c/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-21

--- a/openspec/changes/security-hardening-tier-c/design.md
+++ b/openspec/changes/security-hardening-tier-c/design.md
@@ -1,0 +1,35 @@
+## Context
+
+Tier C 特性是「會動到運作中行為、需搭配後端」。前端 `parseJWT` 未驗簽；專案嵌 Vimeo 播放器 + `_document.tsx` 載入 GTM（含 inline script），CSP 需謹慎；OAuth 由後端提供授權 URL、前端轉發 `code`。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 授權不依賴未驗證的 JWT claims。
+- 導入 CSP 而不破壞既有功能（Vimeo / GTM）。
+- OAuth 流程具備 CSRF 防護。
+
+**Non-Goals:**
+- Tier A / Tier B 的項目。
+- 一步到位的強制 CSP。
+
+## Decisions
+
+1. **JWT**：前端無簽章密鑰、不自行驗簽；改為授權決策一律以後端驗簽結果為準，移除 `check-current-user` 的未驗證判斷。後端（`anna-cook-backend`）以密鑰/公鑰驗簽。
+2. **CSP**：先 `Content-Security-Policy-Report-Only` 收集報告，放行 `player.vimeo.com`、`*.googletagmanager.com`、後端圖片網域、必要 inline（nonce 或 hash）；穩定後改為強制 `Content-Security-Policy`。
+3. **OAuth state**：由後端在授權 URL 產生 `state`、callback 驗證，前端配合帶回。
+
+## Risks / Trade-offs
+
+- [CSP 一步到位擋掉 Vimeo/GTM] → 一律 report-only 先行、逐步放行。
+- [移除前端 isCurrentUser 判斷造成 UI 行為改變] → 以後端 `isMe` 為準，逐頁驗證。
+- [OAuth 改動需後端配合] → 與後端重建一起排程。
+
+## Migration Plan
+
+CSP 分兩階段（report-only → enforce）；JWT / OAuth 與後端協調上線；回滾＝移除 CSP 標頭 / revert。
+
+## Open Questions
+
+- CSP 最終來源白名單與 inline script 處理（nonce vs hash）。
+- 後端驗簽與 OAuth `state` 的介面約定。

--- a/openspec/changes/security-hardening-tier-c/proposal.md
+++ b/openspec/changes/security-hardening-tier-c/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+延續前端資安檢查（Tier A 已完成並歸檔）。本提案納入 **Tier C** —— 會動到運作中行為、需搭配後端或謹慎導入的項目：JWT 驗簽、CSP、OAuth CSRF 防護。對應 issue #165。
+
+## What Changes
+
+- **JWT 驗簽 / 移除未驗證信任**：`src/lib/auth-middleware.ts` 的 `parseJWT` 與 `check-current-user` 只解碼 payload、未驗簽，可偽造 claims。授權判斷改以（會驗簽的）後端結果為準；後端務必驗簽。
+- **CSP**：Tier A 已加其他安全標頭但刻意未含 CSP。以 `Content-Security-Policy-Report-Only` 先行，逐步放行 Vimeo / GTM / 後端圖片後改為強制。
+- **OAuth `state`**：Google 登入流程加入 `state` 產生與驗證，防登入 CSRF。
+
+## Capabilities
+
+### New Capabilities
+- `jwt-signature-verification`: JWT claims 僅在驗簽後才可信任，未驗證 claims 不得作為授權依據
+- `content-security-policy`: 導入 CSP（先 report-only 再強制），涵蓋既有第三方來源
+- `oauth-csrf-protection`: OAuth 授權流程使用並驗證 `state`
+
+### Modified Capabilities
+_(無)_
+
+## Impact
+
+- **程式碼**：`src/lib/auth-middleware.ts`、`src/pages/api/user/check-current-user.ts`、`next.config.ts`、`src/pages/api/auth/google/*`，以及 **anna-cook-backend**（驗簽、OAuth）
+- **行為相容性**：會改動「是否本人」判斷、加入 CSP（需先 report-only 調校）、OAuth 流程
+- **相依**：需與後端重建協調

--- a/openspec/changes/security-hardening-tier-c/specs/content-security-policy/spec.md
+++ b/openspec/changes/security-hardening-tier-c/specs/content-security-policy/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: 必須導入 Content-Security-Policy
+應用程式 SHALL 提供 CSP：先以 `Content-Security-Policy-Report-Only` 收集違規，穩定後以 `Content-Security-Policy` 強制，且涵蓋既有必要來源（Vimeo、GTM、後端圖片）而不破壞功能。
+
+#### Scenario: 導入初期（report-only）
+- **WHEN** CSP 以 report-only 模式部署
+- **THEN** 既有頁面功能正常，違規以報告收集而不被封鎖
+
+#### Scenario: 強制階段
+- **WHEN** CSP 改為強制模式
+- **THEN** 未列入白名單的 inline/外部來源被封鎖，Vimeo 播放器與 GTM 仍正常運作

--- a/openspec/changes/security-hardening-tier-c/specs/jwt-signature-verification/spec.md
+++ b/openspec/changes/security-hardening-tier-c/specs/jwt-signature-verification/spec.md
@@ -1,0 +1,8 @@
+## ADDED Requirements
+
+### Requirement: 授權決策不得依賴未驗證的 JWT claims
+系統 MUST NOT 以未經簽章驗證的 JWT claims 作為授權或身分判斷依據；此類判斷 SHALL 以會驗簽的後端結果為準。
+
+#### Scenario: 偽造 JWT claims
+- **WHEN** 使用者提供一個簽章無效、但 payload 聲稱為他人身分的 JWT
+- **THEN** 系統不因該 payload 給予對應權限或身分，授權以後端驗簽結果為準

--- a/openspec/changes/security-hardening-tier-c/specs/oauth-csrf-protection/spec.md
+++ b/openspec/changes/security-hardening-tier-c/specs/oauth-csrf-protection/spec.md
@@ -1,0 +1,8 @@
+## ADDED Requirements
+
+### Requirement: OAuth 流程必須使用並驗證 state
+Google OAuth 授權流程 SHALL 產生不可預測的 `state` 並在 callback 驗證，未通過驗證的回調 MUST 被拒絕。
+
+#### Scenario: callback 的 state 不符或缺失
+- **WHEN** OAuth callback 帶回的 `state` 與發起時不符或缺失
+- **THEN** 系統拒絕該回調，不建立登入狀態

--- a/openspec/changes/security-hardening-tier-c/tasks.md
+++ b/openspec/changes/security-hardening-tier-c/tasks.md
@@ -1,0 +1,21 @@
+## 1. JWT 驗簽（jwt-signature-verification）
+
+- [ ] 1.1 後端（anna-cook-backend）實作 JWT 簽章驗證
+- [ ] 1.2 前端移除 `check-current-user` 等以未驗證 claims 做的判斷，改以後端結果為準
+- [ ] 1.3 逐頁驗證「是否本人」行為正確
+
+## 2. CSP（content-security-policy）
+
+- [ ] 2.1 以 `Content-Security-Policy-Report-Only` 部署，收集違規報告
+- [ ] 2.2 放行 Vimeo / GTM / 後端圖片、處理 inline script（nonce 或 hash）
+- [ ] 2.3 穩定後改為強制 `Content-Security-Policy`
+
+## 3. OAuth state（oauth-csrf-protection）
+
+- [ ] 3.1 後端在授權 URL 產生 `state`、callback 驗證
+- [ ] 3.2 前端配合帶回 `state`
+
+## 4. 驗收
+
+- [ ] 4.1 逐頁走查（登入、含 Vimeo 的食譜頁、GTM）功能正常
+- [ ] 4.2 `openspec validate security-hardening-tier-c --strict` 通過


### PR DESCRIPTION
## 摘要

以 OpenSpec 建立 **Tier B / Tier C** 資安加固的變更提案（**僅規格文件，不含程式碼**）。延續已完成並歸檔的 Tier A（#161–#163），對應追蹤票 #164 / #165。兩個 change 為獨立目錄，可分開審閱。

## security-hardening-tier-b（對應 #164）
非破壞性、但需選對參數並實測：
- `file-upload-limits` — 上傳大小/型別限制 + 串流（防 DoS）
- `dependency-security` — 無 high/critical CVE、Next.js 保持受支援版本
- `api-path-parameter-safety` — 路徑參數組後端 URL 前驗證/編碼

## security-hardening-tier-c（對應 #165）
會動到現有行為、需搭配後端或謹慎導入：
- `jwt-signature-verification` — 授權不依賴未驗證 JWT claims（後端驗簽）
- `content-security-policy` — 導入 CSP（report-only 先行，涵蓋 Vimeo/GTM）
- `oauth-csrf-protection` — OAuth `state`

## 驗證
`openspec validate --strict`：兩個 change 皆通過，各 4/4 artifacts 完整。

## 後續
實作時各自走 `implement → archive`；Tier C 建議搭配 `anna-cook-backend` 重建一起規劃。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
