### PR TITLE
fix: resolve production recipe image URLs

### DIFF
--- a/src/__tests__/lib/utils/media.test.ts
+++ b/src/__tests__/lib/utils/media.test.ts
@@ -1,0 +1,92 @@
+import { getImageUrl } from '@/lib/utils/media';
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalApiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+const originalDevApiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL_DEV;
+const originalAssetBaseUrl = process.env.NEXT_PUBLIC_ASSET_BASE_URL;
+
+const restoreEnvironmentVariable = (
+  name: string,
+  value: string | undefined,
+) => {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+
+  process.env[name] = value;
+};
+
+describe('getImageUrl', () => {
+  beforeEach(() => {
+    process.env.NODE_ENV = 'production';
+    process.env.NEXT_PUBLIC_API_BASE_URL =
+      'https://annacook.rocket-coding.com/api';
+    delete process.env.NEXT_PUBLIC_API_BASE_URL_DEV;
+    delete process.env.NEXT_PUBLIC_ASSET_BASE_URL;
+  });
+
+  afterAll(() => {
+    restoreEnvironmentVariable('NODE_ENV', originalNodeEnv);
+    restoreEnvironmentVariable('NEXT_PUBLIC_API_BASE_URL', originalApiBaseUrl);
+    restoreEnvironmentVariable(
+      'NEXT_PUBLIC_API_BASE_URL_DEV',
+      originalDevApiBaseUrl,
+    );
+    restoreEnvironmentVariable(
+      'NEXT_PUBLIC_ASSET_BASE_URL',
+      originalAssetBaseUrl,
+    );
+  });
+
+  it('returns the fallback for an empty image path', () => {
+    expect(getImageUrl(null, '/images/fallback.jpg')).toBe(
+      '/images/fallback.jpg',
+    );
+  });
+
+  it('keeps absolute HTTP and HTTPS URLs unchanged', () => {
+    expect(getImageUrl('https://cdn.example.com/image.webp')).toBe(
+      'https://cdn.example.com/image.webp',
+    );
+    expect(getImageUrl('http://localhost:3000/image.webp')).toBe(
+      'http://localhost:3000/image.webp',
+    );
+  });
+
+  it('derives the asset host from an API URL with an /api path', () => {
+    expect(getImageUrl('/RecipeCoverPhoto/example.webp')).toBe(
+      'https://annacook.rocket-coding.com/RecipeCoverPhoto/example.webp',
+    );
+    expect(getImageUrl('RecipeCoverPhoto/example.webp')).toBe(
+      'https://annacook.rocket-coding.com/RecipeCoverPhoto/example.webp',
+    );
+  });
+
+  it('uses the development API host during local development', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.NEXT_PUBLIC_API_BASE_URL_DEV = 'http://localhost:5000/api';
+
+    expect(getImageUrl('/RecipeCoverPhoto/example.webp')).toBe(
+      'http://localhost:5000/RecipeCoverPhoto/example.webp',
+    );
+  });
+
+  it('prefers an explicit asset base URL and normalizes slashes', () => {
+    process.env.NEXT_PUBLIC_ASSET_BASE_URL = 'https://cdn.example.com/assets/';
+
+    expect(getImageUrl('/RecipeCoverPhoto/example.webp')).toBe(
+      'https://cdn.example.com/assets/RecipeCoverPhoto/example.webp',
+    );
+  });
+
+  it('never emits undefined when image configuration is missing', () => {
+    delete process.env.NEXT_PUBLIC_API_BASE_URL;
+    delete process.env.NEXT_PUBLIC_API_BASE_URL_DEV;
+
+    const result = getImageUrl('/RecipeCoverPhoto/example.webp');
+
+    expect(result).toBe('/placeholder.svg');
+    expect(result).not.toContain('undefined');
+  });
+});

--- a/src/components/pages/AuthorProfile/AuthorRecipes.tsx
+++ b/src/components/pages/AuthorProfile/AuthorRecipes.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { RecipeCard } from '@/components/features/RecipeCard';
 import { fetchUserRecipes } from '@/services/users';
 import { COMMON_TEXTS, ERROR_MESSAGES } from '@/lib/constants/messages';
+import { getImageUrl } from '@/lib/utils/media';
 import { cn } from '@/lib/utils/ui';
 import {
   recipesSectionVariants,
@@ -11,8 +12,6 @@ import {
   loadMoreButtonVariants,
   loadingStateVariants,
 } from '@/styles/cva/author-profile';
-
-const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL_DEV;
 
 interface AuthorRecipesProps {
   displayId: string;
@@ -83,9 +82,7 @@ export const AuthorRecipes = ({
   const formatRecipeForCard = (apiRecipe: any) => ({
     id: apiRecipe.recipeId.toString(),
     title: apiRecipe.title,
-    image: apiRecipe.coverPhoto
-      ? `${apiBaseUrl}${apiRecipe.coverPhoto}`
-      : '/images/recipe-placeholder.jpg',
+    image: getImageUrl(apiRecipe.coverPhoto, '/images/recipe-placeholder.jpg'),
     description: apiRecipe.description,
     time: apiRecipe.cookTime,
     cookingTime: apiRecipe.cookTime,

--- a/src/components/pages/RecipeDraft/index.tsx
+++ b/src/components/pages/RecipeDraft/index.tsx
@@ -18,6 +18,7 @@ import { useUserDisplayId } from '@/hooks/useUserDisplayId';
 import { useRecipeDraftStore } from '@/stores/recipes/useRecipeDraftStore';
 import type { Ingredient, Seasoning } from '@/types/recipe';
 import { COMMON_TEXTS } from '@/lib/constants/messages';
+import { getImageUrl } from '@/lib/utils/media';
 import {
   draftPageVariants,
   draftSectionVariants,
@@ -34,9 +35,6 @@ import { IngredientList } from './IngredientList';
 import { TagSection } from './TagsSection';
 import { CookingInfo } from './CookingInfo';
 import { CookingStep } from './CookingSteps';
-
-// API 基礎 URL
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL_DEV;
 
 /**
  * 食譜草稿編輯器元件 - 用於建立和編輯食譜草稿
@@ -339,11 +337,7 @@ export default function RecipeDraft() {
             >
               {recipeImage ? (
                 <img
-                  src={
-                    recipeImage.startsWith('http')
-                      ? recipeImage
-                      : `${API_BASE_URL}${recipeImage}`
-                  }
+                  src={getImageUrl(recipeImage, '/placeholder.svg')}
                   alt="食譜封面"
                   className="object-cover w-full h-full rounded"
                 />

--- a/src/components/pages/RecipePage/index.tsx
+++ b/src/components/pages/RecipePage/index.tsx
@@ -31,6 +31,7 @@ import {
   fetchRecipeRatingComments,
 } from '@/services/recipes';
 import { RecipeRatingCommentResponse } from '@/types/api';
+import { getImageUrl } from '@/lib/utils/media';
 
 // 引入樣式
 import {
@@ -92,28 +93,6 @@ interface RecipePageProps {
     }[];
   };
 }
-
-/**
- * 處理圖片URL，如果不是絕對URL則加上API基礎URL
- */
-const getImageUrl = (coverPhoto: string | null | undefined): string => {
-  if (!coverPhoto) {
-    return '/placeholder.svg?height=500&width=500';
-  }
-
-  // 檢查是否已經是絕對URL (以 http:// 或 https:// 開頭)
-  if (coverPhoto.startsWith('http://') || coverPhoto.startsWith('https://')) {
-    return coverPhoto;
-  }
-
-  // 檢查是否已經是完整的相對路徑 (以 / 開頭)
-  if (coverPhoto.startsWith('/')) {
-    return `${process.env.NEXT_PUBLIC_API_BASE_URL_DEV}${coverPhoto}`;
-  }
-
-  // 其他情況，確保路徑前有 /
-  return `${process.env.NEXT_PUBLIC_API_BASE_URL_DEV}/${coverPhoto}`;
-};
 
 /**
  * 食譜詳情頁面元件，顯示食譜的完整資訊、社交互動和評論
@@ -321,7 +300,10 @@ export default function RecipePageComponent({ recipeData }: RecipePageProps) {
         {/* 食譜主圖 */}
         <div className={mainImageStyles}>
           <Image
-            src={getImageUrl(recipe.coverPhoto)}
+            src={getImageUrl(
+              recipe.coverPhoto,
+              '/placeholder.svg?height=500&width=500',
+            )}
             alt={recipe.recipeName}
             fill
             className="object-cover"

--- a/src/hooks/useUserCenter.ts
+++ b/src/hooks/useUserCenter.ts
@@ -11,18 +11,14 @@ import {
   deleteMultipleRecipes,
 } from '@/services/recipes';
 import { COMMON_TEXTS, ERROR_MESSAGES } from '@/lib/constants/messages';
+import { getImageUrl } from '@/lib/utils/media';
 import type { FavoriteTabType } from '@/components/pages/UserCenter/types';
-
-// 獲取 API 基礎 URL
-const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL_DEV;
 
 /**
  * 將相對路徑轉換為完整的圖片 URL
  */
 const getFullImageUrl = (path: string) => {
-  if (!path) return '/placeholder.svg';
-  if (path.startsWith('http')) return path; // 已經是完整URL
-  return `${apiBaseUrl}${path}`;
+  return getImageUrl(path, '/placeholder.svg');
 };
 
 /**

--- a/src/lib/utils/media.ts
+++ b/src/lib/utils/media.ts
@@ -1,0 +1,56 @@
+const DEFAULT_IMAGE_FALLBACK = '/placeholder.svg';
+
+const getConfiguredApiBaseUrl = (): string | undefined => {
+  if (
+    process.env.NODE_ENV === 'development' &&
+    process.env.NEXT_PUBLIC_API_BASE_URL_DEV
+  ) {
+    return process.env.NEXT_PUBLIC_API_BASE_URL_DEV;
+  }
+
+  return process.env.NEXT_PUBLIC_API_BASE_URL;
+};
+
+const getAssetBaseUrl = (): string | undefined => {
+  const configuredAssetBaseUrl = process.env.NEXT_PUBLIC_ASSET_BASE_URL;
+  const baseUrl = configuredAssetBaseUrl || getConfiguredApiBaseUrl();
+
+  if (!baseUrl) return undefined;
+
+  try {
+    const parsedUrl = new URL(baseUrl);
+
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      return undefined;
+    }
+
+    // API URLs include `/api`, while uploaded images are served from the host root.
+    return configuredAssetBaseUrl ? parsedUrl.toString() : parsedUrl.origin;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Converts an API-provided image path into a safe absolute URL.
+ */
+export const getImageUrl = (
+  path: string | null | undefined,
+  fallback: string = DEFAULT_IMAGE_FALLBACK,
+): string => {
+  if (!path) return fallback;
+
+  if (path.startsWith('http://') || path.startsWith('https://')) {
+    return path;
+  }
+
+  const assetBaseUrl = getAssetBaseUrl();
+  if (!assetBaseUrl) return fallback;
+
+  const normalizedBaseUrl = assetBaseUrl.endsWith('/')
+    ? assetBaseUrl
+    : `${assetBaseUrl}/`;
+  const normalizedPath = path.replace(/^\/+/, '');
+
+  return new URL(normalizedPath, normalizedBaseUrl).toString();
+};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/services/server-api';
 import { SORT_TYPES } from '@/lib/constants';
 import { COMMON_TEXTS } from '@/lib/constants/messages';
+import { getImageUrl } from '@/lib/utils/media';
 import { PageSEO } from '@/components/seo/PageSEO';
 import {
   organizationStructuredData,
@@ -192,9 +193,10 @@ export default function HomePage({
     return {
       id: recipe.id.toString(),
       title: recipe.recipeName,
-      image: recipe.coverPhoto
-        ? `${process.env.NEXT_PUBLIC_API_BASE_URL_DEV}${recipe.coverPhoto}`
-        : '/placeholder.svg?height=150&width=150',
+      image: getImageUrl(
+        recipe.coverPhoto,
+        '/placeholder.svg?height=150&width=150',
+      ),
       description: recipe.author,
       rating: recipe.rating,
     };
@@ -209,9 +211,10 @@ export default function HomePage({
     return {
       id: recipe.id.toString(),
       title: recipe.recipeName,
-      image: recipe.coverPhoto
-        ? `${process.env.NEXT_PUBLIC_API_BASE_URL_DEV}${recipe.coverPhoto}`
-        : '/placeholder.svg?height=80&width=80',
+      image: getImageUrl(
+        recipe.coverPhoto,
+        '/placeholder.svg?height=80&width=80',
+      ),
       category: '',
       time: recipe.cookingTime,
       cookingTime: recipe.cookingTime,

--- a/src/pages/recipe-list/index.tsx
+++ b/src/pages/recipe-list/index.tsx
@@ -11,6 +11,7 @@ import { searchRecipesServer } from '@/services/server-api';
 import { GetStaticProps } from 'next';
 import { SORT_TYPES, PAGINATION_DEFAULTS } from '@/lib/constants';
 import { COMMON_TEXTS } from '@/lib/constants/messages';
+import { getImageUrl } from '@/lib/utils/media';
 import { PageSEO } from '@/components/seo/PageSEO';
 
 // 定義頁面 props 介面
@@ -63,9 +64,10 @@ export default function RecipeListPage({
           const newRecipes = data.data.map((item: any) => ({
             id: String(item.id),
             title: item.recipeName,
-            image: item.coverPhoto
-              ? `${process.env.NEXT_PUBLIC_API_BASE_URL_DEV}${item.coverPhoto}`
-              : '/images/recipe-placeholder.jpg',
+            image: getImageUrl(
+              item.coverPhoto,
+              '/images/recipe-placeholder.jpg',
+            ),
             category: '',
             time: item.cookingTime,
             cookingTime: item.cookingTime,
@@ -419,9 +421,7 @@ export const getStaticProps: GetStaticProps = async () => {
     const recipes: RecipeCardType[] = searchResults.data.map((item) => ({
       id: String(item.id),
       title: item.recipeName,
-      image: item.coverPhoto
-        ? `${process.env.NEXT_PUBLIC_API_BASE_URL_DEV}${item.coverPhoto}`
-        : '/images/recipe-placeholder.jpg',
+      image: getImageUrl(item.coverPhoto, '/images/recipe-placeholder.jpg'),
       category: '', // 填入空字串，因為這個欄位是必須的
       time: item.cookingTime,
       cookingTime: item.cookingTime,

--- a/src/pages/recipe-page/[...id].tsx
+++ b/src/pages/recipe-page/[...id].tsx
@@ -9,6 +9,7 @@ import { HTTP_STATUS, REVALIDATE_INTERVALS } from '@/lib/constants';
 import { COMMON_TEXTS, ERROR_MESSAGES } from '@/lib/constants/messages';
 import { RecipeSEO } from '@/components/seo/RecipeSEO';
 import { truncateDescription } from '@/lib/utils/seo';
+import { getImageUrl } from '@/lib/utils/media';
 
 interface RecipePageProps {
   recipeData: RecipeDetailResponse;
@@ -51,9 +52,7 @@ const RecipePage: NextPage<RecipePageProps> = ({ recipeData }) => {
   // 構建食譜圖片陣列
   const recipeImages: string[] = [];
   if (recipe.coverPhoto) {
-    recipeImages.push(
-      `${process.env.NEXT_PUBLIC_API_BASE_URL_DEV}${recipe.coverPhoto}`,
-    );
+    recipeImages.push(getImageUrl(recipe.coverPhoto, '/images/og-default.jpg'));
   }
 
   // 由於 API 回傳的資料結構中沒有 recipeSteps，這裡暫時註解掉


### PR DESCRIPTION
## What changed

- add a shared `getImageUrl()` helper for API-provided image paths
- derive the asset origin from `NEXT_PUBLIC_API_BASE_URL` so the API `/api` path is not added to uploaded-image URLs
- keep the development override and support an optional `NEXT_PUBLIC_ASSET_BASE_URL`
- migrate all seven production image URL call sites to the shared helper
- add regression tests for fallbacks, absolute URLs, slash normalization, environment selection, and missing configuration

## Root cause

Production injects `NEXT_PUBLIC_API_BASE_URL=https://annacook.rocket-coding.com/api`, but the image call sites read `NEXT_PUBLIC_API_BASE_URL_DEV`. That variable is undefined in the production bundle, so Next Image received URLs such as:

```
/_next/image?url=undefined%2FRecipeCoverPhoto%2F...
```

and returned HTTP 400 with `"url" parameter is invalid`.

Uploaded images are served from the host root rather than under `/api`, so the helper safely derives `https://annacook.rocket-coding.com` from the configured API URL.

## Validation

- targeted regression tests: 6 passed
- full Jest suite: 26 suites passed, 562 tests passed, 2 skipped
- `npm run lint`: passed with pre-existing warnings only
- production build with `NEXT_PUBLIC_API_BASE_URL_DEV` unset: passed
- built bundle contains no `undefined/RecipeCoverPhoto` URL pattern
