### PR TITLE
fix: remove dead re-exports of emptied http module (fixes prod build)

### DIFF
--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,6 +1,3 @@
-// 匯出 utils 工具
-export * from './utils/http';
-
 // 匯出認證服務模組
 export * from './auth';
 

--- a/src/services/utils/index.ts
+++ b/src/services/utils/index.ts
@@ -1,1 +1,1 @@
-export * from './http';
+export {};


### PR DESCRIPTION
## 問題
#170（dev→main）後首次在 main 真正 build 就失敗（`next build` → Failed to compile）：

```
./src/services/index.ts        2:15  Error: No named exports found in module './utils/http'.  import/export
./src/services/utils/index.ts  1:15  Error: No named exports found in module './http'.  import/export
```

## 根因
安全強化 Tier A（#162）把 `src/services/utils/http.ts` 的 client token 存取器整個移除、只留空模組（`export {}`），但兩個 barrel 仍 `export * from './http'`。對「無具名匯出」的模組做 `export *`，ESLint `import/export` 會報 error，Next 預設把它當 build 失敗——清理時漏刪的死 re-export。

## 修正
- `src/services/index.ts`：移除 `export * from './utils/http';`
- `src/services/utils/index.ts`：`export * from './http';` → `export {};`

grep 全 repo 確認無任何地方依賴這些（被移除的 `getAuthToken`/`updateAuthToken` 已無使用者）。

## 驗證
本地 `npm run build`（node 22，與 Docker 一致）**編譯成功**（exit 0，全頁產出）；pre-commit 的 ESLint + 554 測試亦全通過。

## 備註
dev 也有同樣的死 re-export，需同步修（或之後 main→dev sync 帶回）。