### PR TITLE
ci: add PR verification workflow (build + test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+# PR 合併前先驗證：build（含 ESLint/typecheck）+ 測試，避免問題拖到 prod 部署才爆。
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      HUSKY: '0' # CI 不需要安裝 git hooks，避免 prepare 腳本呼叫 husky 失敗
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (含 ESLint + typecheck)
+        run: npm run build
+        env:
+          NEXT_PUBLIC_API_BASE_URL: https://annacook.rocket-coding.com/api
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## 目的
新增 `on: pull_request`（base = main/dev）的 CI，PR 合併前先跑：
- `npm ci`（`HUSKY=0`）
- `npm run build`（含 ESLint + typecheck──就是這次連環爆的那些檢查）
- `npm test`（jest）

## 為什麼
先前 repo 只有「push main 才跑」的 deploy workflow，**dev 的 PR 從沒在 CI build 過**，導致 build/lint 問題一路拖到 prod 部署才爆（缺 deploy.yml→舊 Dockerfile→死 `export *` 三連環）。有了這個 gate，問題在合併前就會被擋下，「先進 dev 再 release main」的流程才真正有保護力。

## 備註
本 workflow 進 dev 後，會在下次 `dev→main` release 一併帶上 main，屆時 main 的 release PR 也會被保護。