### PR TITLE
release: promote dev to main (add PR verification CI workflow)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, dev]
+
+# PR 合併前先驗證：build（含 ESLint/typecheck）+ 測試，避免問題拖到 prod 部署才爆。
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      HUSKY: '0' # CI 不需要安裝 git hooks，避免 prepare 腳本呼叫 husky 失敗
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build (含 ESLint + typecheck)
+        run: npm run build
+        env:
+          NEXT_PUBLIC_API_BASE_URL: https://annacook.rocket-coding.com/api
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
## 目的
把 dev 目前唯一領先 main 的變更帶上 main,讓兩邊分支重新對齊。

## 起因
上次 release(#170)之後 main 已補上部署相關修復,但少了 #173 新增的 `ci.yml`(PR 驗證用的 build+lint+test)。目前 main/dev 的差異只剩這一個檔案,沒有任何 app code 改動。

## 帶上 main 的東西
- `.github/workflows/ci.yml`:對 `main`/`dev` 開 PR 時跑 `npm ci` → `npm run build`(含 ESLint + typecheck) → `npm test`

## Merge 後會發生
merge 進 main = push-to-main → 觸發 `deploy.yml` 重新 build + 部署(app code 未變,等同重建同一份內容)、同時也會觸發 Zeabur 既有的自動部署,兩邊都要留意。

## 注意
- dev 領先 main 的內容只有這個 workflow 檔案,範圍小、風險低。
- `ci.yml` 目前沒有 branch protection / required status checks 把關,合併不會被它擋下,純粹新增檢查機制,尚未強制生效。
- `ci.yml` 唯一一次執行紀錄是失敗的(#173 首跑時撞到當時尚未 back-merge 的死 export 錯誤),但合併時機正好卡在同日 #172 back-merge 之後,目前 dev HEAD 已無該問題。這個 PR 本身開啟後會觸發 `ci.yml` 對 dev→main 的檢查,可以當作第一次乾淨驗證。