### PR TITLE
fix: raise upload size limits (image 10MB, video 500MB)

### DIFF
--- a/src/lib/upload.ts
+++ b/src/lib/upload.ts
@@ -5,8 +5,8 @@ import fs from 'node:fs';
  * 上傳檔案大小上限（bytes）。
  * 注意：此為前端保守預設值，實際上線前應與後端限制對齊。
  */
-export const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MB
-export const MAX_VIDEO_BYTES = 200 * 1024 * 1024; // 200 MB
+export const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB（涵蓋高解析手機照片）
+export const MAX_VIDEO_BYTES = 500 * 1024 * 1024; // 500 MB
 
 /**
  * 允許的圖片 MIME 類型白名單


### PR DESCRIPTION
## 摘要

上 prod 前的小調整：放寬 Tier B 導入的前端上傳大小上限。

## 為什麼

Tier B 設的是 **圖片 5MB / 影片 200MB**，但**升級前上傳為「無上限」**——5MB 會擋掉正常的高解析手機照片（一張 12MP+ 照片常 5–8MB），對食譜作者是回歸。

## 變更

`src/lib/upload.ts`：**圖片 5→10MB、影片 200→500MB**。仍是前端保守 guard（OOM / 濫用防護），**後端為真正的 enforcer**；上線後再與後端實際限制對齊。

（build/test 交由 CI 驗證——僅兩個常數變更。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
