### PR TITLE
test: fix e2e auth setup and realign test suite (fix-e2e-test-suite)

### DIFF
--- a/openspec/changes/fix-e2e-test-suite/.openspec.yaml
+++ b/openspec/changes/fix-e2e-test-suite/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-23

--- a/openspec/changes/fix-e2e-test-suite/design.md
+++ b/openspec/changes/fix-e2e-test-suite/design.md
@@ -1,0 +1,50 @@
+## Context
+
+e2e 套件（`tests/e2e/**`，19 個檔、~150 個 `test()`）以 Playwright 撰寫，跨 6 個專案（no-auth ×2、auth ×4）。診斷（2026-07-23）發現兩層問題：
+
+1. **認證從未供裝**：`setup` 專案匹配 0 檔 → `tests/.auth/user.json` 不存在 → 所有 auth 測試 `ENOENT` 即死。
+2. **測試對照的是另一個 App**：測試需 216 個 `data-testid`，App 僅有 3 個（Button 變體）；抽樣功能掛鉤 0 命中。實測 `/upload-video` 畫面正常，證明「畫面沒問題、是測試對不上」，且大量測試瞄準**尚未實作**的功能。
+
+登入真實流程為 `/signin-email` →（`POST /api/auth/email/login` → 後端 `/auth/login`，body `{AccountEmail, Password}`）→ 設 `HttpOnly` `token` cookie。此流程已用測試帳號實測可行。
+
+## Goals / Non-Goals
+
+**Goals:**
+- 讓認證 setup 可重現地產生已登入 storageState（憑證走環境變數）。
+- 讓 `npx playwright test` 收斂為「保留集全綠 + 未實作集 skipped + 0 非預期失敗」。
+- 為保留的真實流程建立穩定、有紀錄的測試掛鉤與 fixture。
+
+**Non-Goals:**
+- 不新建 216 個掛鉤或未實作功能（播放器／時間軸／縮圖／頻寬監測）。
+- 不變更任何產品行為。
+- 不在本變更內把 quarantine 的功能「做出來」（另立 backlog）。
+
+## Decisions
+
+1. **認證以真實登入供裝（採 A 的精神但範圍極小）**：改寫 `auth.setup.ts` 走 `/signin-email`，憑證讀 `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`，成功判斷＝導回 `/` 且持有 `token` cookie。避免（a）寫死密碼進版控、（b）依賴不存在的 `user-menu` 掛鉤。
+2. **不採「純 A」也不採「純 B」，改採 triage**：
+   - **純 A（把 216 個掛鉤全補上）不成立**——多數掛鉤沒有對應元素，等於要先「蓋出」整組未實作功能才能掛 testid，那是被生成測試牽著做產品。
+   - **純 B（把 148 個測試全改寫對應現有 UI）不成立**——無法把測試改去檢查不存在的 `bandwidth-indicator` 等；那些測試沒有真實標的。
+   - 結論：**逐檔分類**，只保留有真實對應的流程（先確定 `upload/*`），其餘 `test.skip` 並記錄原因為 backlog。
+3. **隱藏 file input 用 `setInputFiles`，不斷言可見**：真實 `#video-upload` 為 `hidden`（點外層拖放區觸發）；Playwright 對隱藏 input 仍可 `setInputFiles`。修正測試 helper 的錯誤斷言。
+4. **少量、有紀錄的 `data-testid`**：只為**保留集**真實元素加掛鉤（如 `video-upload-input` / `video-upload-dropzone`），而非全套 216 個。
+
+## Risks / Trade-offs
+
+- [大量測試被 skip 會讓「覆蓋率」看起來下降] → 但這是誠實反映：原本是 ~592 紅燈測空氣功能。以 backlog 清單保留意圖，功能實作時再解 skip。
+- [在 `src` 加 `data-testid` 動到產品碼] → 僅新增屬性、無行為影響；範圍限保留集元素。
+- [CI 需要測試帳號 secrets] → 以 `TEST_USER_EMAIL` / `TEST_USER_PASSWORD` 提供；缺少時 setup 明確失敗而非用寫死值。
+- [測試帳號 / 後端可用性] → 認證依賴 `anna-cook-backend`；後端不可用時 setup 失敗會連鎖，需在 CI 前置健康檢查。
+
+## Migration Plan
+
+1. 先落地認證 Foundation（第 1 節），確認 `setup` 產生 storageState。
+2. 盤點分類（第 2 節），把未實作集 `test.skip`——此時全套即可「綠 + skipped」。
+3. 補 upload 保留集的掛鉤／斷言／fixture（第 3 節）使其真綠。
+4. 回滾＝revert 測試與設定變更；`data-testid` 屬性可獨立保留（無害）。
+
+## Open Questions
+
+- `upload/*` 之外，`editor` / `thumbnails` 是否有**部分**真實對應（如 `recipe-video` 的編輯步驟）可納入保留集？需第 2 節盤點確認。
+- fixture 影片採「提交小型樣本」或「setup 動態產生（ffmpeg）」？影響 repo 體積與 CI 相依。
+- CI 測試帳號的來源與輪替策略（共用測試帳號 vs 每次 seed）。

--- a/openspec/changes/fix-e2e-test-suite/proposal.md
+++ b/openspec/changes/fix-e2e-test-suite/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Playwright e2e「一堆 fail」的根因不是最近壞掉，而是**從未接上**：
+
+- `playwright.config.ts` 的 `setup` 專案 `testDir: './tests/e2e'` 但 `testMatch: /.*\.setup\.ts/`，而 `tests/auth.setup.ts` 在 `tests/e2e/` **之外** → `setup` 匹配 **0 個測試**（`playwright test --project=setup --list` 回報 `Total: 0`）→ `tests/.auth/user.json` **從未產生** → 148 個需認證測試 × 4 個 auth 專案（**~592 個 run**）全在載入 storageState 時 `ENOENT` 死掉。只有 2 個首頁 no-auth 測試是綠的。
+- 更深一層的落差：測試依賴 **216 個** 不同的 `data-testid`，但 App 只有 **3 個**（皆為 Button 變體 `default-btn` / `destructive-btn` / `outline-btn`，非功能掛鉤）。抽樣 `fullscreen-button`、`timeline-container`、`segment-list`、`thumbnail-grid`、`bandwidth-indicator`、`buffer-progress`、`drag-drop-area`、`video-player` 於 `src/` **0 命中**——測試描述的是一個**大部分尚未實作**的 App。
+
+診斷於 2026-07-23：以 chrome-devtools 實測登入後的 `/upload-video`，**畫面正常**（三步驟精靈、「上傳您的影片」、可用的 `<input type="file" accept="video/*" id="video-upload">`），失敗純因測試 selector（`video-upload-input`）、斷言（對 `hidden` input 斷 `toBeVisible`）、與缺 fixture 影片。對應 e2e 修復需求。
+
+## What Changes
+
+- **認證 Foundation**：修 `playwright.config.ts` 讓 `setup` 專案抓得到 `tests/auth.setup.ts`；改寫 `auth.setup.ts` 走真實 `/signin-email` 流程、憑證改讀環境變數、成功判斷改為「導回 `/` 且持有 `token` cookie」（移除對不存在的 `[data-testid="user-menu"]` 依賴）。
+- **分類重整（triage）**：逐檔對照真實路由/元件，把測試標記為 keep / rewrite / **quarantine**；未實作功能的測試以 `test.skip` + 原因保留為 backlog，不追求讓空氣功能變綠。
+- **保留最小綠集**：對真實存在的 `upload/*` 流程，在真實元件補**少量**穩定 `data-testid`、修 hidden-input 斷言（改用 `setInputFiles`）、供裝 fixture 影片。
+
+### Non-Goals
+
+- **不**為了滿足生成測試而新建 216 個測試掛鉤，或整組尚未實作的功能（自製播放器、時間軸/片段編輯器、縮圖產生器、頻寬/緩衝監測）。
+- **不**變更任何產品行為；本變更僅動測試基礎建設與（少量）測試掛鉤。
+
+## Capabilities
+
+### New Capabilities
+
+- `e2e-auth-provisioning`：e2e 以真實 `/signin-email` + 環境變數憑證供裝「已登入」的 storageState，且 `setup` 專案可被 Playwright 探測到。
+- `e2e-suite-alignment`：e2e 僅覆蓋**已實作**的功能；未實作者一律 quarantine（skip + 原因）；保留的流程具穩定且有紀錄的 selector 與可供裝的 fixture。
+
+### Modified Capabilities
+
+_(無)_
+
+## Impact
+
+- **測試／設定**：`playwright.config.ts`、`tests/auth.setup.ts`、`tests/config/test-config.ts`、`tests/helpers/video/*`、`tests/fixtures/videos/`、`tests/README.md`
+- **程式碼（少量）**：於真實上傳元件補 `data-testid`（`src/pages/upload-video` 及相關元件）
+- **行為相容性**：不改動產品行為；僅新增測試掛鉤與測試基礎建設
+- **CI**：需提供 `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`（secrets）；非 CI 由既有 webServer 走 `localhost:3000`
+- **相依**：認證流程依賴 `anna-cook-backend` 的 `/auth/login`（已於 2026-07-23 實測可用）

--- a/openspec/changes/fix-e2e-test-suite/specs/e2e-auth-provisioning/spec.md
+++ b/openspec/changes/fix-e2e-test-suite/specs/e2e-auth-provisioning/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: 認證 setup 必須真的產生已登入的 storageState
+
+e2e 測試框架 SHALL 透過驅動真實的 `/signin-email` 登入流程，產生 `tests/.auth/user.json`（含有效的認證 `token` cookie），供所有需認證的 Playwright 專案以 `storageState` 載入。`setup` 專案 SHALL 能被 Playwright 探測到（匹配非 0 個測試）。
+
+#### Scenario: setup 執行後產生 storageState
+
+- **WHEN** `setup` 專案執行
+- **THEN** 以 `/signin-email` 成功登入，並將含 `token` cookie 的 storageState 寫入 `tests/.auth/user.json`
+
+#### Scenario: setup 專案能被 Playwright 探測
+
+- **WHEN** 執行 `npx playwright test --project=setup --list`
+- **THEN** 匹配到 `tests/auth.setup.ts`（總數非 0），而非回報 `Total: 0 tests`
+
+#### Scenario: 認證檔缺失時不再是 ENOENT 連鎖
+
+- **WHEN** auth 專案（如 `chromium-auth`）在 `setup` 依賴執行後啟動
+- **THEN** `storageState` 檔存在且可載入，測試不再以 `ENOENT: ./tests/.auth/user.json` 失敗
+
+### Requirement: 認證憑證不得寫死於版控
+
+認證憑證 SHALL 來自環境變數 `TEST_USER_EMAIL` 與 `TEST_USER_PASSWORD`；已提交的 `auth.setup.ts` MUST NOT 含寫死的密碼。缺少憑證時，setup SHALL 以清楚訊息失敗，而非退回使用寫死值。
+
+#### Scenario: 憑證由環境變數提供
+
+- **WHEN** 已設定 `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`
+- **THEN** setup 以該憑證登入，且原始碼中不出現明文密碼
+
+#### Scenario: 缺少憑證時明確失敗
+
+- **WHEN** 未設定 `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`
+- **THEN** setup 以「缺少測試憑證」的清楚訊息失敗，且不使用任何寫死密碼
+
+### Requirement: 成功判斷以真實登入結果為準
+
+登入成功 SHALL 以「導回 `/` 且持有認證 `token` cookie」判定，MUST NOT 依賴應用程式中不存在的 UI 掛鉤（例如 `[data-testid="user-menu"]`）。
+
+#### Scenario: 以導頁與 cookie 判定成功
+
+- **WHEN** 於 `/signin-email` 提交有效憑證
+- **THEN** 頁面導回 `/` 且瀏覽器 context 具備 `token` cookie，據此判定登入成功

--- a/openspec/changes/fix-e2e-test-suite/specs/e2e-suite-alignment/spec.md
+++ b/openspec/changes/fix-e2e-test-suite/specs/e2e-suite-alignment/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: e2e 測試只覆蓋已實作的功能
+
+e2e 套件 SHALL 僅對應用程式中**確實存在**的功能與 selector 進行斷言。瞄準尚未實作功能（例如自製播放器、時間軸／片段編輯器、縮圖產生器、頻寬／緩衝監測）的測試 MUST 以 `test.skip` 或 `test.describe.skip`（整檔）並註明原因加以 quarantine，並列入 backlog，而非放任其失敗。全套執行結果 SHALL 為「保留集通過、quarantine 集 skipped、0 個非預期失敗」。
+
+#### Scenario: 未實作功能的測試被 quarantine
+
+- **WHEN** 某測試瞄準應用程式中不存在的功能或 `data-testid`（如 `timeline-container`、`bandwidth-indicator`）
+- **THEN** 該（檔）測試以 `test.describe.skip`（或 `test.skip`）標記、檔頭註明原因並記錄於 backlog，不計為失敗
+
+#### Scenario: 全套執行收斂
+
+- **WHEN** 執行 `npx playwright test`
+- **THEN** 保留集全數通過、quarantine 集顯示為 skipped、且回報 0 個非預期失敗（unexpected）
+
+### Requirement: 保留的真實流程必須有穩定且有紀錄的測試 selector
+
+對保留在套件中的真實流程，應用程式 SHALL 在其實際互動的元素上提供穩定、有紀錄的 `data-testid`（例如影片上傳的 input 與拖放區）。測試對於**隱藏**的檔案 input MUST 以 `setInputFiles` 直接設定檔案，而非斷言其可見。
+
+#### Scenario: 上傳 input 具穩定掛鉤且以 setInputFiles 操作
+
+- **WHEN** 上傳測試選取影片檔
+- **THEN** 測試以 `data-testid`（如 `video-upload-input`）定位真實的 `#video-upload` 隱藏 input，並以 `setInputFiles` 設定檔案，而不斷言該 input 可見
+
+### Requirement: 測試素材必須可供裝
+
+上傳相關測試所需的 fixture 影片 SHALL 以可重現方式供裝（提交小型樣本，或於 setup 動態產生），使測試不因缺檔而失敗，且 `getDefaultTestVideo()` 回傳的檔名與實際素材一致。
+
+#### Scenario: fixture 影片就位
+
+- **WHEN** 上傳測試在 `beforeEach` 取得 `getDefaultTestVideo()` 的路徑
+- **THEN** `tests/fixtures/videos/` 內存在對應的小型影片檔，測試可據以上傳

--- a/openspec/changes/fix-e2e-test-suite/tasks.md
+++ b/openspec/changes/fix-e2e-test-suite/tasks.md
@@ -1,0 +1,28 @@
+## 1. 認證 Foundation（e2e-auth-provisioning）
+
+- [x] 1.1 修 `playwright.config.ts`：讓 `setup` 專案抓得到 `tests/auth.setup.ts`（`setup` 專案給定 `testDir: './tests'` + `testMatch: /auth\.setup\.ts/`，或把檔案移進 `tests/e2e/`）— 已驗證 `--project=setup --list` 由 0 → 1 test
+- [x] 1.2 改寫 `tests/auth.setup.ts`：改走 `/signin-email`（非 `/login`），以 placeholder 定位 email／password 欄位；**送出改由頁面內呼叫表單本身使用的登入 API**（approach B — 避免 UI hydration/analytics flaky，符合 Playwright auth setup 建議）
+- [x] 1.3 憑證改讀環境變數 `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`；缺少時明確拋錯，**不**寫死密碼
+- [x] 1.4 成功判斷改為「登入 API 200 + `/api/auth/check` 200 + 存在 `token` cookie」，移除對不存在的 `[data-testid="user-menu"]` 依賴
+- [x] 1.5 驗證：`npx playwright test --project=setup --list` = 1（原 0）；執行後 setup 綠、產生含 `token` cookie 的 `tests/.auth/user.json`
+
+> 註：此登入流程已於 2026-07-23 用測試帳號實測可行——`/api/auth/email/login` 回 200、發 `HttpOnly` `token` cookie、`/api/auth/check` 回 200；瀏覽器走 `/signin-email` 亦成功導回 `/`。本節為把該 spike 正式落地成可重現的 setup。
+
+## 2. 現況盤點與分類（e2e-suite-alignment）
+
+- [x] 2.1 逐檔對照 5 大類（`upload` / `editor` / `thumbnails` / `error-handling` / `integration` / `cross-browser`）與真實路由（`upload-video`、`recipe-video`、`recipe-draft-video` …）與元件，標記 keep / rewrite / quarantine — 決策：僅 upload 頁真實可測，其餘全 quarantine
+- [x] 2.2 產出對照表：測試要求的 216 個 `data-testid` vs 現有 3 個 — 見 `triage.md`（3 個皆 Button 變體、非功能掛鉤；抽樣功能掛鉤 0 命中）
+- [x] 2.3 未實作功能的測試 → `test.describe.skip`（比 beforeEach+test.skip 乾淨，連 before/afterEach 一併跳過，避免對未導頁的 page 清理而報錯），原因記於檔頭註解；已 quarantine 全部 18 個 video 測試檔
+
+## 3. 保留 upload 真功能為綠（e2e-suite-alignment）
+
+- [x] 3.1 在真實元件補少量穩定 `data-testid`：`UploadArea.tsx` 的 `#video-upload` input → `video-upload-input`；外層拖放區 → `video-upload-dropzone`（已於 fresh dev server 驗證 testids 生效、smoke 通過）
+- [x] 3.2 修 `tests/helpers/video/video-upload.ts`：`toBeVisible` → `toBeAttached`，改以 `setInputFiles` 直接設定隱藏 input
+- [x] 3.3 供裝 fixture：改用 smoke 測試內的記憶體 `video/mp4` buffer（bundled ffmpeg 無法產 mp4/webm，且不手造二進位）— 已寫入 `upload-smoke.test.ts`
+- [x] 3.4 新增 `upload-smoke.test.ts` 於 `chromium-auth` 綠燈 — 已於本機 fresh dev server（:3002）驗證通過（setup + smoke = 2 passed）
+
+## 4. 收斂與驗收
+
+- [x] 4.1 chromium-engine 全跑（no-auth + auth + mobile）：5 passed（setup+homepage+smoke×2）、**292 skipped**、**0 failures** — ⚠️ firefox/webkit 引擎未安裝（`npx playwright install firefox webkit` 後可補跑，測試邏輯相同）
+- [x] 4.2 更新 `tests/README.md`：說明認證前置（env 憑證 + E2E_BASE_URL）、fixture、quarantine 政策
+- [x] 4.3 `openspec validate fix-e2e-test-suite --strict` 通過（valid）

--- a/openspec/changes/fix-e2e-test-suite/triage.md
+++ b/openspec/changes/fix-e2e-test-suite/triage.md
@@ -1,0 +1,29 @@
+# e2e 測試分類（triage）
+
+診斷日（2026-07-23）量測：測試依賴 **216** 個不同的 `data-testid`，但 App 原本只有 **3** 個
+（`default-btn` / `destructive-btn` / `outline-btn`，皆 Button 變體、非功能掛鉤）。抽樣測試假設
+存在的功能掛鉤（`fullscreen-button`、`timeline-container`、`segment-list`、`thumbnail-grid`、
+`bandwidth-indicator`、`buffer-progress`、`drag-drop-area`、`video-player`）於 `src/` **0 命中**。
+結論：多數測試描述的是尚未實作的功能。
+
+## 各區決策
+
+| 區域 | 檔數 | 對應真實路由/元件 | 決策 | 原因 |
+|---|---|---|---|---|
+| `upload/*` | 3 | `/upload-video`（`UploadArea`：真實 dropzone + 隱藏 `#video-upload`） | **quarantine**（另建 smoke） | 現有測試仍需 `upload-progress`/`upload-success`/`video-preview`/`video-controls` 等未實作掛鉤；只有「選檔→顯示檔名」可測 → 改由新 `upload-smoke.test.ts` 覆蓋 |
+| `editor/*` | 4 | 無（時間軸/片段/播放器編輯器未實作） | quarantine | 編輯器 UI 未實作 |
+| `thumbnails/*` | 3 | 無（縮圖產生器未實作） | quarantine | 縮圖功能未實作 |
+| `error-handling/*` | 2 | 無（頻寬/資源限制 UI 未實作） | quarantine | 錯誤處理 UI 未實作 |
+| `integration/*` | 2 | 無（依賴上述多項） | quarantine | 完整流程依賴未實作功能 |
+| `cross-browser/*` | 4 | 無（跨瀏覽器跑上述流程） | quarantine | 依賴未實作的播放器/上傳掛鉤 |
+
+## 保留集（green）
+
+- `navigation/01-homepage.test.ts`（no-auth）— 首頁 smoke。
+- `video/upload/upload-smoke.test.ts`（auth，新增）— 登入 → `/upload-video` dropzone 可見 →
+  `setInputFiles`（記憶體 `video/mp4`）→ 顯示檔名。同時驗證整條 harness（auth setup → storageState → 受保護頁）。
+
+## Backlog（解除 quarantine 的條件）
+
+每個 quarantine 檔頭已註明原因。當對應功能（播放器、時間軸/片段編輯器、縮圖、上傳進度/錯誤 UI…）
+實作並提供對應 `data-testid` 後，將該檔的 `test.describe.skip` 改回 `test.describe` 並逐案對齊真實 UI。

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,10 +24,12 @@ export default defineConfig({
 
   // 全域設定
   use: {
-    // 基礎 URL
-    baseURL: process.env.CI
-      ? 'https://anna-cook.zeabur.app/'
-      : 'http://localhost:3000',
+    // 基礎 URL（可用 E2E_BASE_URL 覆寫，例如指向本機自建的 dev server）
+    baseURL:
+      process.env.E2E_BASE_URL ||
+      (process.env.CI
+        ? 'https://anna-cook.zeabur.app/'
+        : 'http://localhost:3000'),
 
     // 追蹤設定
     trace: 'on-first-retry',
@@ -47,7 +49,10 @@ export default defineConfig({
   projects: [
     {
       name: 'setup',
-      testMatch: /.*\.setup\.ts/,
+      // auth.setup.ts 位於 tests/ 根層（testDir 為 tests/e2e），故此專案自訂 testDir
+      // 並精準匹配 auth.setup.ts，避免掃到 tests/setup/video/*.setup.ts
+      testDir: './tests',
+      testMatch: /auth\.setup\.ts/,
     },
     // 不需要認證的測試（如首頁、公開頁面）
     {
@@ -103,15 +108,16 @@ export default defineConfig({
     },
   ],
 
-  // 本地開發伺服器
-  webServer: process.env.CI
-    ? undefined
-    : {
-        command: 'npm run dev',
-        url: 'http://localhost:3000',
-        reuseExistingServer: !process.env.CI,
-        timeout: 120 * 1000,
-      },
+  // 本地開發伺服器（設定 E2E_BASE_URL 時代表使用外部伺服器，跳過自動啟動）
+  webServer:
+    process.env.CI || process.env.E2E_BASE_URL
+      ? undefined
+      : {
+          command: 'npm run dev',
+          url: 'http://localhost:3000',
+          reuseExistingServer: !process.env.CI,
+          timeout: 120 * 1000,
+        },
 
   // 輸出目錄
   outputDir: 'test-results/',

--- a/src/components/pages/VideoUpload/UploadArea.tsx
+++ b/src/components/pages/VideoUpload/UploadArea.tsx
@@ -64,6 +64,7 @@ export default function UploadArea({
 
       <div
         className={uploadContainerVariants({ state: getContainerState() })}
+        data-testid="video-upload-dropzone"
         onClick={() =>
           !isUploading && document.getElementById('video-upload')?.click()
         }
@@ -72,6 +73,7 @@ export default function UploadArea({
           type="file"
           accept="video/*"
           id="video-upload"
+          data-testid="video-upload-input"
           className="hidden"
           onChange={onUpload}
           disabled={isUploading}

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,6 +34,43 @@ TEST_USER_EMAIL=your-test-email@example.com
 TEST_USER_PASSWORD=your-test-password
 ```
 
+## 🔑 認證（auth setup）
+
+需認證的測試依賴 `tests/auth.setup.ts` 產生的 `tests/.auth/user.json`（由 `setup` 專案先跑）。
+它以**真實 `/signin-email` 流程**登入：填入帳密後，透過表單本身使用的登入 API 送出，
+成功判斷為「登入 API 200 + `/api/auth/check` 200 + 取得 `token` cookie」。
+
+- 憑證**必須**由環境變數提供，缺少時 setup 會明確失敗（不使用任何寫死值）：
+  ```bash
+  TEST_USER_EMAIL=... TEST_USER_PASSWORD=... npm run test:e2e
+  ```
+  （Playwright 不會自動載入 `.env.local`，請走 shell env 或你的 env 管理工具。）
+
+## 🖥️ 對「本機當前程式碼」跑（PR gating）
+
+e2e 的價值是在合併/部署前擋回歸，因此應對**當前程式碼**跑，而非已部署的 PROD。
+可用 `E2E_BASE_URL` 覆寫 baseURL 指向本機自建的伺服器（設定後會自動略過內建 webServer）：
+
+```bash
+# 另起一個載入 .env 的本機伺服器（例：port 3002），再讓測試指向它
+E2E_BASE_URL=http://localhost:3002 TEST_USER_EMAIL=... TEST_USER_PASSWORD=... \
+  npx playwright test --project=chromium-auth
+```
+
+> ⚠️ 後端注意：`.env` 的 `NEXT_PUBLIC_API_BASE_URL_DEV` 目前**缺少 `/api`**（PROD 的
+> `NEXT_PUBLIC_API_BASE_URL` 有），dev 模式登入會打到 `/auth/login` 而得到 401。對本機 dev
+> 驗證時請覆寫為含 `/api` 的值（`NEXT_PUBLIC_API_BASE_URL_DEV=https://annacook.rocket-coding.com/api`）。
+>
+> ⚠️ DEV 與 PROD **共用同一後端**，沒有獨立 staging；請只用「非寫入」測試 + 專用測試帳號，避免污染正式資料。
+
+## 🧟 Quarantine 政策
+
+`tests/e2e/video/**` 目前有 18 個測試檔瞄準**尚未實作**的功能（播放器、時間軸/片段編輯器、
+縮圖、上傳進度/錯誤 UI…），已用 **`test.describe.skip`** quarantine（檔頭註明原因），保留為 backlog、
+不刪除；待功能實作並提供對應 `data-testid` 後再逐案解除。分類詳見
+`openspec/changes/fix-e2e-test-suite/triage.md`。目前的綠燈保留集：`navigation/01-homepage.test.ts`
+與 `video/upload/upload-smoke.test.ts`。
+
 ## 📖 測試結構
 
 ### 助手函式

--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -1,23 +1,75 @@
 import { test as setup, expect } from '@playwright/test';
+import fs from 'node:fs';
+import path from 'node:path';
 
 /**
- * 認證設定 - 為所有測試準備登入狀態
+ * 認證狀態儲存路徑（供需認證的測試以 storageState 載入）
  */
-setup('authenticate', async ({ page }) => {
-  // 前往登入頁面
-  await page.goto('/login');
+const AUTH_FILE = 'tests/.auth/user.json';
 
-  // 執行登入流程（根據實際登入流程調整）
-  await page.fill('input[type="email"]', 'test@example.com');
-  await page.fill('input[type="password"]', 'testpassword');
-  await page.click('button[type="submit"]');
+/**
+ * 從環境變數取得測試帳號憑證；缺少時明確失敗，不使用任何寫死的預設值
+ */
+const getTestCredentials = (): { email: string; password: string } => {
+  const email = process.env.TEST_USER_EMAIL;
+  const password = process.env.TEST_USER_PASSWORD;
 
-  // 等待登入完成
-  await page.waitForURL('/');
+  if (!email || !password) {
+    throw new Error(
+      '缺少測試憑證：請先設定環境變數 TEST_USER_EMAIL 與 TEST_USER_PASSWORD，再執行 e2e 認證 setup。',
+    );
+  }
 
-  // 驗證登入成功
-  await expect(page.locator('[data-testid="user-menu"]')).toBeVisible();
+  return { email, password };
+};
 
-  // 保存認證狀態
-  await page.context().storageState({ path: './tests/.auth/user.json' });
+/**
+ * 認證設定 - 以真實 /signin-email 登入流程取得已登入 session 並保存 storageState。
+ * 送出改由頁面內呼叫表單本身使用的登入 API，避免 UI hydration/analytics 造成的 setup flaky
+ * （亦符合 Playwright 對 auth setup 以 API 登入的建議）。
+ */
+setup('authenticate', async ({ page, context }) => {
+  const { email, password } = getTestCredentials();
+
+  // 前往電子郵件登入頁（真實登入頁，而非只有 Google 按鈕的 /login）
+  await page.goto('/signin-email', { waitUntil: 'domcontentloaded' });
+
+  // 以 placeholder 定位真實欄位並填入帳號密碼（驗證登入頁結構正確）
+  await page.getByPlaceholder('請輸入您的電子信箱').fill(email);
+  await page.getByPlaceholder('請輸入您的密碼').fill(password);
+
+  // 透過表單本身使用的登入 API 送出，並確認 session 有效（/api/auth/check）
+  const result = await page.evaluate(
+    async ({ email: accountEmail, password: accountPassword }) => {
+      const loginResponse = await fetch('/api/auth/email/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: accountEmail, password: accountPassword }),
+      });
+      const loginBody = (await loginResponse.json()) as { StatusCode?: number };
+      const checkResponse = await fetch('/api/auth/check', {
+        credentials: 'include',
+      });
+      return {
+        loginStatus: loginResponse.status,
+        loginStatusCode: loginBody?.StatusCode,
+        checkStatus: checkResponse.status,
+      };
+    },
+    { email, password },
+  );
+
+  // 成功判斷（其一）：登入與 session 檢查皆成功
+  expect(result.loginStatus, '登入 API 應回應 HTTP 200').toBe(200);
+  expect(result.loginStatusCode, '登入回應的 StatusCode 應為 200').toBe(200);
+  expect(result.checkStatus, '登入後 /api/auth/check 應回應 200（session 有效）').toBe(200);
+
+  // 成功判斷（其二）：瀏覽器持有認證 token cookie（不依賴不存在的 user-menu 掛鉤）
+  const cookies = await context.cookies();
+  const hasTokenCookie = cookies.some((cookie) => cookie.name === 'token');
+  expect(hasTokenCookie, '登入後應存在認證 token cookie').toBe(true);
+
+  // 確保目錄存在後保存認證狀態
+  fs.mkdirSync(path.dirname(AUTH_FILE), { recursive: true });
+  await context.storageState({ path: AUTH_FILE });
 });

--- a/tests/e2e/video/cross-browser/chromium.test.ts
+++ b/tests/e2e/video/cross-browser/chromium.test.ts
@@ -34,7 +34,9 @@ type CodecSupport = {
 /**
  * Chrome 特定功能測試
  */
-test.describe('Chrome 瀏覽器特定功能', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（跨瀏覽器影片流程依賴未實作的播放器/上傳 UI 掛鉤）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('Chrome 瀏覽器特定功能', () => {
   /**
    * 每個測試前的準備工作
    */

--- a/tests/e2e/video/cross-browser/firefox.test.ts
+++ b/tests/e2e/video/cross-browser/firefox.test.ts
@@ -5,7 +5,9 @@ import { getTestFilePath } from '../../../helpers/common/test-data';
 /**
  * Firefox 兼容性測試
  */
-test.describe('Firefox 瀏覽器兼容性', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（跨瀏覽器影片流程依賴未實作的播放器/上傳 UI 掛鉤）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('Firefox 瀏覽器兼容性', () => {
   /**
    * 每個測試前的準備工作
    */

--- a/tests/e2e/video/cross-browser/mobile.test.ts
+++ b/tests/e2e/video/cross-browser/mobile.test.ts
@@ -5,7 +5,9 @@ import { getTestFilePath } from '../../../helpers/common/test-data';
 /**
  * 行動瀏覽器專用測試
  */
-test.describe('行動瀏覽器兼容性', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（跨瀏覽器影片流程依賴未實作的播放器/上傳 UI 掛鉤）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('行動瀏覽器兼容性', () => {
   /**
    * 每個測試前的準備工作 - 設定行動裝置
    */

--- a/tests/e2e/video/cross-browser/webkit.test.ts
+++ b/tests/e2e/video/cross-browser/webkit.test.ts
@@ -51,7 +51,9 @@ type SafariJavaScriptSupport = {
 /**
  * Safari/WebKit 兼容性測試
  */
-test.describe('Safari/WebKit 瀏覽器兼容性', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（跨瀏覽器影片流程依賴未實作的播放器/上傳 UI 掛鉤）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('Safari/WebKit 瀏覽器兼容性', () => {
   /**
    * 每個測試前的準備工作
    */

--- a/tests/e2e/video/editor/form-validation.test.ts
+++ b/tests/e2e/video/editor/form-validation.test.ts
@@ -25,7 +25,9 @@ type TestFormData = {
 /**
  * 表單驗證邏輯測試
  */
-test.describe('影片編輯表單驗證功能', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（影片編輯器（時間軸/片段/播放器）未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('影片編輯表單驗證功能', () => {
   /**
    * 每個測試前的準備工作
    */

--- a/tests/e2e/video/editor/segment-management.test.ts
+++ b/tests/e2e/video/editor/segment-management.test.ts
@@ -22,7 +22,9 @@ import { getDefaultTestVideo } from '../../../helpers/common/test-data';
 /**
  * 片段管理功能測試
  */
-test.describe('片段管理功能', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（影片編輯器（時間軸/片段/播放器）未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('片段管理功能', () => {
   let videoDuration: number;
 
   /**

--- a/tests/e2e/video/editor/timeline-controls.test.ts
+++ b/tests/e2e/video/editor/timeline-controls.test.ts
@@ -33,7 +33,9 @@ async function parseTimeFromTooltip(tooltipText: string): Promise<number> {
 /**
  * 時間軸操作測試
  */
-test.describe('時間軸操作控制', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（影片編輯器（時間軸/片段/播放器）未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('時間軸操作控制', () => {
   let videoDuration: number;
 
   /**

--- a/tests/e2e/video/editor/video-player.test.ts
+++ b/tests/e2e/video/editor/video-player.test.ts
@@ -20,7 +20,9 @@ import { getDefaultTestVideo } from '../../../helpers/common/test-data';
 /**
  * 影片播放器基本功能測試
  */
-test.describe('影片播放器基本功能', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（影片編輯器（時間軸/片段/播放器）未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('影片播放器基本功能', () => {
   /**
    * 每個測試前的準備工作
    */

--- a/tests/e2e/video/error-handling/network-errors.test.ts
+++ b/tests/e2e/video/error-handling/network-errors.test.ts
@@ -5,7 +5,9 @@ import { getTestFilePath } from '../../../helpers/common/test-data';
 /**
  * 網路錯誤處理測試
  */
-test.describe('網路錯誤處理功能', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（上傳錯誤處理/資源限制 UI 未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('網路錯誤處理功能', () => {
   /**
    * 每個測試前的準備工作
    */

--- a/tests/e2e/video/error-handling/resource-limitations.test.ts
+++ b/tests/e2e/video/error-handling/resource-limitations.test.ts
@@ -5,7 +5,9 @@ import { getTestFilePath } from '../../../helpers/common/test-data';
 /**
  * 資源限制處理測試
  */
-test.describe('資源限制處理功能', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（上傳錯誤處理/資源限制 UI 未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('資源限制處理功能', () => {
   /**
    * 每個測試前的準備工作
    */

--- a/tests/e2e/video/integration/complete-workflow.test.ts
+++ b/tests/e2e/video/integration/complete-workflow.test.ts
@@ -5,7 +5,9 @@ import { getTestFilePath } from '../../../helpers/common/test-data';
 /**
  * 完整使用者流程測試
  */
-test.describe('完整使用者工作流程', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（完整流程整合所需的多項 UI 掛鉤未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('完整使用者工作流程', () => {
   /**
    * 每個測試前的準備工作
    */

--- a/tests/e2e/video/integration/error-recovery.test.ts
+++ b/tests/e2e/video/integration/error-recovery.test.ts
@@ -5,7 +5,9 @@ import { getTestFilePath } from '../../../helpers/common/test-data';
 /**
  * 錯誤恢復測試
  */
-test.describe('錯誤恢復功能', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（完整流程整合所需的多項 UI 掛鉤未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('錯誤恢復功能', () => {
   /**
    * 每個測試前的準備工作
    */

--- a/tests/e2e/video/thumbnails/desktop-thumbnails.test.ts
+++ b/tests/e2e/video/thumbnails/desktop-thumbnails.test.ts
@@ -27,7 +27,9 @@ import { getDefaultTestVideo } from '../../../helpers/common/test-data';
 /**
  * 桌面版縮圖生成功能測試
  */
-test.describe('桌面版縮圖生成功能', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（縮圖產生功能未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('桌面版縮圖生成功能', () => {
   /**
    * 每個測試前的準備工作
    */

--- a/tests/e2e/video/thumbnails/mobile-thumbnails.test.ts
+++ b/tests/e2e/video/thumbnails/mobile-thumbnails.test.ts
@@ -22,7 +22,9 @@ import { getDefaultTestVideo } from '../../../helpers/common/test-data';
 /**
  * 行動版縮圖生成功能測試
  */
-test.describe('行動版縮圖生成功能', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（縮圖產生功能未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('行動版縮圖生成功能', () => {
   /**
    * 每個測試前的準備工作
    */

--- a/tests/e2e/video/thumbnails/thumbnail-quality.test.ts
+++ b/tests/e2e/video/thumbnails/thumbnail-quality.test.ts
@@ -19,7 +19,9 @@ import { getDefaultTestVideo } from '../../../helpers/common/test-data';
 /**
  * 縮圖品質驗證測試
  */
-test.describe('縮圖品質驗證功能', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（縮圖產生功能未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('縮圖品質驗證功能', () => {
   /**
    * 每個測試前的準備工作
    */

--- a/tests/e2e/video/upload/file-upload.test.ts
+++ b/tests/e2e/video/upload/file-upload.test.ts
@@ -19,7 +19,9 @@ import { getDefaultTestVideo } from '../../../helpers/common/test-data';
 /**
  * 影片檔案上傳功能測試
  */
-test.describe('影片檔案上傳功能', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（上傳進度/成功/預覽等 UI 掛鉤未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('影片檔案上傳功能', () => {
   let testVideoPath: string;
 
   /**

--- a/tests/e2e/video/upload/file-validation.test.ts
+++ b/tests/e2e/video/upload/file-validation.test.ts
@@ -38,7 +38,9 @@ type ValidationError = {
 /**
  * 檔案驗證和錯誤處理測試
  */
-test.describe('檔案驗證和錯誤處理', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（上傳進度/成功/預覽等 UI 掛鉤未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('檔案驗證和錯誤處理', () => {
   /**
    * 每個測試前的準備工作
    */

--- a/tests/e2e/video/upload/upload-progress.test.ts
+++ b/tests/e2e/video/upload/upload-progress.test.ts
@@ -19,7 +19,9 @@ import { getDefaultTestVideo } from '../../../helpers/common/test-data';
 /**
  * 上傳進度和狀態測試
  */
-test.describe('上傳進度和狀態管理', () => {
+// [quarantine] e2e-suite-alignment：整檔測試瞄準尚未實作的功能（上傳進度/成功/預覽等 UI 掛鉤未實作）。
+// 以 test.describe.skip quarantine 保留為 backlog，待功能實作後解除；詳見 openspec/changes/fix-e2e-test-suite。
+test.describe.skip('上傳進度和狀態管理', () => {
   let testVideoPath: string;
 
   /**

--- a/tests/e2e/video/upload/upload-smoke.test.ts
+++ b/tests/e2e/video/upload/upload-smoke.test.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * 影片上傳頁最小 smoke 測試。
+ * 只斷言真實存在的行為：已登入 → 上傳頁可見 → 以 setInputFiles 選檔 → 顯示檔名。
+ * （現有 upload/* 等測試因依賴未實作 UI 已 quarantine；此檔為對應真實流程的最小綠燈，
+ *   同時驗證整條 harness：auth setup → storageState → 受保護頁面可存取。）
+ */
+test.describe('影片上傳頁 smoke', () => {
+  /**
+   * 驗證登入狀態下可於上傳頁選取影片並顯示檔名
+   */
+  test('應該能在登入後於上傳頁選取影片並顯示檔名', async ({ page }) => {
+    // 已登入（storageState）狀態下前往上傳頁（未登入會被導回 /login）
+    await page.goto('/upload-video');
+
+    // 上傳拖放區應可見（真實存在的元素，代表頁面已載入且通過認證）
+    await expect(page.getByTestId('video-upload-dropzone')).toBeVisible();
+
+    // 隱藏的檔案 input 以 setInputFiles 直接設定（不斷言可見）；
+    // 使用記憶體內的最小 video/mp4 檔，避免依賴外部影片素材
+    await page.getByTestId('video-upload-input').setInputFiles({
+      name: 'test-video-short.mp4',
+      mimeType: 'video/mp4',
+      buffer: Buffer.from('mp4 smoke fixture'),
+    });
+
+    // 選取後應顯示所選檔名（UploadArea 於 fileName 存在時渲染檔名）
+    await expect(page.getByText('test-video-short.mp4')).toBeVisible();
+  });
+});

--- a/tests/helpers/video/video-upload.ts
+++ b/tests/helpers/video/video-upload.ts
@@ -97,10 +97,10 @@ export const uploadVideoFile = async (
   // 取得檔案上傳輸入元素
   const fileInput = await getVideoUploadInput(page);
 
-  // 確認檔案輸入元素存在
-  await expect(fileInput).toBeVisible();
+  // 確認檔案輸入元素已掛載（隱藏 input 為拖放區標準設計，故不斷言可見）
+  await expect(fileInput).toBeAttached();
 
-  // 設定檔案
+  // 設定檔案（setInputFiles 可作用於隱藏 input）
   await fileInput.setInputFiles(filePath);
 
   // 等待檔案選擇完成，使用配置中的延遲或預設值


### PR DESCRIPTION
## 摘要

修復 Playwright e2e「一堆 fail」的根因並重整套件。

- **根因**：`setup` 專案 `testDir` 與 `auth.setup.ts` 位置不符 → 匹配 0 檔 → `tests/.auth/user.json` 從未產生 → 所有需登入測試以 `ENOENT` 崩潰。
- **更深層**：測試依賴 **216** 個 `data-testid`，但 App 只有 **3** 個（皆 Button 變體），多數測試瞄準**尚未實作**的功能（自製播放器、時間軸/片段編輯器、縮圖、頻寬監測…）。以 chrome-devtools 實測 `/upload-video`：畫面正常、是測試/spec 不符，非 UI bug。

## 變更

- **認證 foundation**：修 `setup` 專案匹配；`auth.setup.ts` 改走真實 `/signin-email`，憑證讀環境變數（`TEST_USER_EMAIL`/`TEST_USER_PASSWORD`，缺少即失敗、不寫死），成功判斷用 `token` cookie（移除不存在的 `user-menu` 依賴）。
- **Triage**：18 個 `video/**` 測試檔以 `test.describe.skip` quarantine（原因見檔頭與 `openspec/changes/fix-e2e-test-suite/triage.md`），保留為 backlog、不刪除。
- **保留最小綠集**：`UploadArea` 補 `video-upload-input`/`video-upload-dropzone` testid；helper `toBeVisible`→`toBeAttached`；新增 `upload-smoke.test.ts`（記憶體 `video/mp4`）。
- `playwright.config`：`baseURL`/`webServer` 可用 `E2E_BASE_URL` 覆寫。
- 含 OpenSpec change `fix-e2e-test-suite`（proposal/design/tasks/specs），`openspec validate --strict` 通過。

## 驗證

- Jest 單元：**567 passed**（pre-commit/pre-push）＋ `npm run build` 成功（pre-push）。
- e2e（chromium 引擎，對本機當前程式碼）：**5 passed / 292 skipped / 0 failures**。

## Caveats / follow-up

- firefox/webkit 未安裝，僅驗證 chromium 引擎（`npx playwright install firefox webkit` 可補跑，測試邏輯相同）。
- `.env` 的 `NEXT_PUBLIC_API_BASE_URL_DEV` 缺 `/api`（prod 有）→ dev 登入 401，需覆寫；已記於 `tests/README.md`。
- DEV/PROD 共用同一後端（`annacook.rocket-coding.com`）→ 目前只保留非寫入測試。
- `playwright.config` 的 CI prod URL（`anna-cook.zeabur.app`）過時，實際 prod 為 `anna-cook.com`。
- OpenSpec change 尚未 `sync`/`archive`（依慣例合併後再做）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
