### PR TITLE
fix: 伺服器端除錯 log 僅在非 production 輸出

### DIFF
--- a/src/services/server-api.ts
+++ b/src/services/server-api.ts
@@ -6,6 +6,18 @@ import { DEV_TEST_TOKEN, HTTP_STATUS, SORT_TYPES } from '@/lib/constants';
 import { ERROR_MESSAGES } from '@/lib/constants/messages';
 
 /**
+ * 僅在非 production 環境輸出伺服器端除錯訊息
+ * 避免請求 URL 與完整 API 回應內容（含使用者資料）被寫入正式環境的容器 log
+ * @param args 要輸出的除錯內容
+ */
+const devLog = (...args: readonly unknown[]): void => {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.log(...args);
+  }
+};
+
+/**
  * 從 IncomingMessage 請求 Cookie 中獲取 JWT Token
  * @param req 伺服器端請求物件
  * @returns JWT Token 或 null
@@ -44,7 +56,7 @@ export const getAuthTokenForServer = (req: IncomingMessage): string | null => {
 
   // 在開發環境中使用測試 token
   if (process.env.NODE_ENV === 'development') {
-    console.log('Using development test token');
+    devLog('Using development test token');
     return DEV_TEST_TOKEN;
   }
 
@@ -97,9 +109,7 @@ export const fetchUserProfileServer = async (
   req: IncomingMessage,
 ): Promise<UserProfileResponse> => {
   try {
-    console.log(
-      `伺服器端發送請求: GET ${getApiConfig().baseUrl}/user/${displayId}`,
-    );
+    devLog(`伺服器端發送請求: GET ${getApiConfig().baseUrl}/user/${displayId}`);
 
     // 獲取 token (若有)
     const token = getAuthTokenForServer(req);
@@ -120,7 +130,7 @@ export const fetchUserProfileServer = async (
       },
     );
 
-    console.log('伺服器端回應狀態:', response.status);
+    devLog('伺服器端回應狀態:', response.status);
 
     if (!response.ok) {
       return {
@@ -178,7 +188,7 @@ export const fetchUserRecipesServer = async (
   page: number = 1,
 ): Promise<UserRecipesResponse> => {
   try {
-    console.log(
+    devLog(
       `伺服器端發送請求: GET ${getApiConfig().baseUrl}/user/${displayId}/recipes?page=${page}`,
     );
 
@@ -187,7 +197,7 @@ export const fetchUserRecipesServer = async (
       `${getApiConfig().baseUrl}/user/${displayId}/recipes?page=${page}`,
     );
 
-    console.log('伺服器端回應狀態:', response.status);
+    devLog('伺服器端回應狀態:', response.status);
 
     // 處理 404 或其他錯誤狀態
     if (!response.ok) {
@@ -212,7 +222,7 @@ export const fetchUserRecipesServer = async (
 
     // 解析回應資料
     const data = await response.json();
-    console.log('伺服器端回應資料:', data);
+    devLog('伺服器端回應資料:', data);
 
     return data;
   } catch (error) {
@@ -276,7 +286,7 @@ export const fetchAuthorRecipesServer = async (
     const queryParam = isPublished ? '?isPublished=true' : '?isPublished=false';
     const apiUrl = `${getApiConfig().baseUrl}/user/${displayId}/management/recipe${queryParam}`;
 
-    console.log(`伺服器端發送請求: GET ${apiUrl}`);
+    devLog(`伺服器端發送請求: GET ${apiUrl}`);
 
     const response = await fetch(apiUrl, {
       method: 'GET',
@@ -285,7 +295,7 @@ export const fetchAuthorRecipesServer = async (
       },
     });
 
-    console.log('伺服器端回應狀態:', response.status);
+    devLog('伺服器端回應狀態:', response.status);
 
     if (!response.ok) {
       return {
@@ -296,7 +306,7 @@ export const fetchAuthorRecipesServer = async (
     }
 
     const data = await response.json();
-    console.log('伺服器端回應資料:', data);
+    devLog('伺服器端回應資料:', data);
 
     return data;
   } catch (error) {
@@ -364,7 +374,7 @@ export const fetchRecipeDetailServer = async (
   req?: IncomingMessage,
 ): Promise<RecipeDetailResponse> => {
   try {
-    console.log(
+    devLog(
       `伺服器端發送請求: GET ${getApiConfig().baseUrl}/recipes/${recipeId}`,
     );
 
@@ -388,7 +398,7 @@ export const fetchRecipeDetailServer = async (
       },
     );
 
-    console.log('伺服器端回應狀態:', response.status);
+    devLog('伺服器端回應狀態:', response.status);
 
     if (!response.ok) {
       return {
@@ -402,7 +412,7 @@ export const fetchRecipeDetailServer = async (
 
     // 解析回應資料
     const data = await response.json();
-    console.log('伺服器端回應資料:', data);
+    devLog('伺服器端回應資料:', data);
 
     return data;
   } catch (error) {
@@ -440,15 +450,13 @@ export interface HomeFeatureResponse {
  */
 export const fetchHomeFeatures = async (): Promise<HomeFeatureResponse> => {
   try {
-    console.log(
-      `伺服器端發送請求: GET ${getApiConfig().baseUrl}/home/features`,
-    );
+    devLog(`伺服器端發送請求: GET ${getApiConfig().baseUrl}/home/features`);
 
     const response = await fetch(`${getApiConfig().baseUrl}/home/features`, {
       next: { revalidate: 3600 },
     });
 
-    console.log('伺服器端回應狀態:', response.status);
+    devLog('伺服器端回應狀態:', response.status);
 
     if (!response.ok) {
       return {
@@ -459,7 +467,7 @@ export const fetchHomeFeatures = async (): Promise<HomeFeatureResponse> => {
     }
 
     const data = await response.json();
-    console.log('伺服器端回應資料:', data);
+    devLog('伺服器端回應資料:', data);
 
     return data;
   } catch (error) {
@@ -503,11 +511,11 @@ export const fetchHomeRecipes = async (
 ): Promise<HomeRecipesResponse> => {
   try {
     const apiUrl = `${getApiConfig().baseUrl}/home/recipes?type=${type}&number=${number}`;
-    console.log(`伺服器端發送請求: GET ${apiUrl}`);
+    devLog(`伺服器端發送請求: GET ${apiUrl}`);
 
     const response = await fetch(apiUrl, { next: { revalidate: 3600 } });
 
-    console.log('伺服器端回應狀態:', response.status);
+    devLog('伺服器端回應狀態:', response.status);
 
     if (!response.ok) {
       return {
@@ -520,7 +528,7 @@ export const fetchHomeRecipes = async (
     }
 
     const data = await response.json();
-    console.log('伺服器端回應資料:', data);
+    devLog('伺服器端回應資料:', data);
 
     return data;
   } catch (error) {
@@ -581,12 +589,12 @@ export const searchRecipesServer = async (
     queryParams.append('number', String(number));
 
     const apiUrl = `${getApiConfig().baseUrl}/recipes/search?${queryParams.toString()}`;
-    console.log(`伺服器端發送請求: GET ${apiUrl}`);
+    devLog(`伺服器端發送請求: GET ${apiUrl}`);
 
     // App Router：資料快取每小時重新驗證（對應原 recipe-list getStaticProps 的 revalidate 3600）
     const response = await fetch(apiUrl, { next: { revalidate: 3600 } });
 
-    console.log('伺服器端回應狀態:', response.status);
+    devLog('伺服器端回應狀態:', response.status);
 
     if (!response.ok) {
       return {
@@ -600,7 +608,7 @@ export const searchRecipesServer = async (
     }
 
     const data = await response.json();
-    console.log('伺服器端回應資料:', data);
+    devLog('伺服器端回應資料:', data);
 
     return data;
   } catch (error) {


### PR DESCRIPTION
## 問題

`src/services/server-api.ts` 有 **21 處 `console.log`** 會把請求 URL 與**完整 API 回應內容**寫進 log，且沒有任何環境判斷 —— 這些函式跑在 server side，**production 容器的 log 同樣會照印**。

其中 `fetchUserProfileServer` / `fetchUserRecipesServer` 打的是 `/user/{displayId}` 相關端點，回應內容含使用者資料（email、追蹤數、個人檔案等）。

實測：`next build` 的靜態生成階段就直接把 2 筆完整 API 回應內容印進 build log。

## 改動

新增 `devLog()` helper，僅在 `NODE_ENV !== 'production'` 時輸出，21 處除錯 log 全數改走它。

`console.error` / `console.warn` 共 9 處屬正當的錯誤記錄，**原樣保留**。

## 驗證

| 項目 | 結果 |
|---|---|
| production build 期間洩漏的 API 回應內容 | 2 筆 → **0 筆** |
| dev server 首頁 | HTTP 200，devLog 正常輸出 |
| `npm test` | 562/562 通過 |
| `npm run lint` / `next build` | 皆 exit 0 |
| 靜態頁生成 | 31/31 |

dev 與 production 兩條路徑都實際跑過，確認除錯訊息在開發時仍看得到、在正式環境完全靜音。

🤖 Generated with [Claude Code](https://claude.com/claude-code)